### PR TITLE
Jws branch

### DIFF
--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -16,6 +16,7 @@ analysis_params = {
                 'normalization' : 'psc',
                 'regress_blinks' : True,
                 'regress_sacs' : True,
+                'use_standard_blinksac_kernels' : False,
                 }
 subjects = [
             'sub-01',
@@ -23,7 +24,6 @@ subjects = [
             ]
 
 def preprocess_subjects(subjects, task, output_dir, analysis_params):
-    """import_all_data loops across the aliases of the sessions and converts the respective edf files, adds them to the self.ho's hdf5 file. """
     
     for subject in subjects:
         
@@ -66,6 +66,7 @@ def preprocess_subjects(subjects, task, output_dir, analysis_params):
                                     normalization=analysis_params['normalization'],
                                     regress_blinks=analysis_params['regress_blinks'],
                                     regress_sacs=analysis_params['regress_sacs'],
+                                    use_standard_blinksac_kernels=analysis_params['use_standard_blinksac_kernels'],
                                     )
         
 def main():

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -16,7 +16,7 @@ analysis_params = {
                 }
 subjects = [
             'sub-01',
-            # 'sub-02',
+            'sub-02',
             ]
 
 def preprocess_subjects(subjects, task, output_dir, analysis_params):

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -10,12 +10,12 @@ task = 'yesno'
 raw_dir = 'raw/'
 output_dir = os.path.expanduser('~/Downloads/pupil_prep/')
 analysis_params = {
-                'hp' : 6.0,
-                'lp' : 0.01,
+                'lp' : 6.0,
+                'hp' : 0.01,
                 'normalization' : 'psc',
                 }
 subjects = [
-            'sub-01',
+            # 'sub-01',
             'sub-02',
             ]
 
@@ -57,8 +57,8 @@ def preprocess_subjects(subjects, task, output_dir, analysis_params):
             ho.add_edf_file(os.path.join(preprocess_dir, 'raw', alias + '.edf'))
             ho.edf_message_data_to_hdf(alias=alias)
             ho.edf_gaze_data_to_hdf(alias=alias,
-                                    pupil_hp=analysis_params['hp'],
                                     pupil_lp=analysis_params['lp'],
+                                    pupil_hp=analysis_params['hp'],
                                     normalization=analysis_params['normalization']
                                     )
 

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import os, glob
+from IPython import embed as shell
+
+import hedfpy
+
+task = 'yesno'
+raw_dir = 'raw/'
+output_dir = os.path.expanduser('~/Downloads/pupil_prep/')
+subjects = [
+            'sub-01',
+            # 'sub-02',
+            ]
+
+def preprocess_subjects(subjects):
+    
+    for subject in subjects:
+    
+        # data:
+        edfs = glob.glob(os.path.join(raw_dir, '{}*{}*.edf'.format(subject, task)))
+    
+        # preprocessing:
+        preprocess_edfs(subject=subject, task=task, edfs=edfs, output_dir=os.path.join(output_dir,task,subject))
+        
+def preprocess_edfs(subject, task, edfs, output_dir):
+    """import_all_data loops across the aliases of the sessions and converts the respective edf files, adds them to the self.ho's hdf5 file. """
+    
+    # folder hierarchy:
+    try:
+        os.makedirs(os.path.join(output_dir, 'raw'))
+    except OSError:
+        pass
+    
+    # hdf5 filename:
+    hdf5_filename = os.path.join(output_dir, '{}_{}.hdf5'.format(subject, task))
+    try:
+        os.remove(hdf5_filename)
+    except OSError:
+        pass
+    
+    # initialize hdf5 HDFEyeOperator:
+    ho = hedfpy.HDFEyeOperator(hdf5_filename)
+    
+    # variables:
+    session_nrs = [r.split('ses-')[1][0:2] for r in edfs]
+    run_nrs = [r.split('run-')[1][0:1] for r in edfs]
+    aliases = []
+    for i in range(len(session_nrs)):
+        aliases.append('{}_{}_{}'.format(task, session_nrs[i], run_nrs[i]))
+    
+    # preprocessing:
+    for (edf_file, alias,) in zip(edfs, aliases):
+        os.system('cp "' + edf_file + '" "' + os.path.join(output_dir, 'raw', alias + '.edf"'))
+    for alias in aliases:
+        ho.add_edf_file(os.path.join(output_dir, 'raw', alias + '.edf'))
+        ho.edf_message_data_to_hdf(alias=alias)
+        ho.edf_gaze_data_to_hdf(alias=alias)
+
+def main():
+    preprocess_subjects(subjects)
+
+if __name__ == '__main__':
+    main()

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -28,14 +28,14 @@ def preprocess_subjects(subjects, task, output_dir, analysis_params):
         edfs = glob.glob(os.path.join(raw_dir, '{}*{}*.edf'.format(subject, task)))
         
         # folder hierarchy:
-        output_dir = os.path.join(output_dir, task, subject)
+        preprocess_dir = os.path.join(output_dir, task, subject)
         try:
-            os.makedirs(os.path.join(output_dir, 'raw'))
+            os.makedirs(os.path.join(preprocess_dir, 'raw'))
         except OSError:
             pass
     
         # hdf5 filename:
-        hdf5_filename = os.path.join(output_dir, '{}_{}.hdf5'.format(subject, task))
+        hdf5_filename = os.path.join(preprocess_dir, '{}_{}.hdf5'.format(subject, task))
         try:
             os.remove(hdf5_filename)
         except OSError:
@@ -53,8 +53,8 @@ def preprocess_subjects(subjects, task, output_dir, analysis_params):
     
         # preprocessing:
         for edf_file, alias in zip(edfs, aliases):
-            os.system('cp "' + edf_file + '" "' + os.path.join(output_dir, 'raw', alias + '.edf"'))
-            ho.add_edf_file(os.path.join(output_dir, 'raw', alias + '.edf'))
+            os.system('cp "' + edf_file + '" "' + os.path.join(preprocess_dir, 'raw', alias + '.edf"'))
+            ho.add_edf_file(os.path.join(preprocess_dir, 'raw', alias + '.edf'))
             ho.edf_message_data_to_hdf(alias=alias)
             ho.edf_gaze_data_to_hdf(alias=alias,
                                     pupil_hp=analysis_params['hp'],

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -8,9 +8,9 @@ import hedfpy
 
 task = 'yesno'
 raw_dir = 'raw/'
-output_dir = os.path.expanduser('~/Downloads/pupil_prep/')
+output_dir = 'preprocessed/'
 analysis_params = {
-                'sample_rate' : 500.0,
+                'sample_rate' : 1000.0,
                 'lp' : 6.0,
                 'hp' : 0.01,
                 'normalization' : 'psc',

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -9,57 +9,61 @@ import hedfpy
 task = 'yesno'
 raw_dir = 'raw/'
 output_dir = os.path.expanduser('~/Downloads/pupil_prep/')
+analysis_params = {
+                'hp' : 6.0,
+                'lp' : 0.01,
+                'normalization' : 'psc',
+                }
 subjects = [
             'sub-01',
             # 'sub-02',
             ]
 
-def preprocess_subjects(subjects):
+def preprocess_subjects(subjects, task, output_dir, analysis_params):
+    """import_all_data loops across the aliases of the sessions and converts the respective edf files, adds them to the self.ho's hdf5 file. """
     
     for subject in subjects:
     
         # data:
         edfs = glob.glob(os.path.join(raw_dir, '{}*{}*.edf'.format(subject, task)))
+        
+        # folder hierarchy:
+        output_dir = os.path.join(output_dir, task, subject)
+        try:
+            os.makedirs(os.path.join(output_dir, 'raw'))
+        except OSError:
+            pass
+    
+        # hdf5 filename:
+        hdf5_filename = os.path.join(output_dir, '{}_{}.hdf5'.format(subject, task))
+        try:
+            os.remove(hdf5_filename)
+        except OSError:
+            pass
+    
+        # initialize hdf5 HDFEyeOperator:
+        ho = hedfpy.HDFEyeOperator(hdf5_filename)
+    
+        # variables:
+        session_nrs = [r.split('ses-')[1][0:2] for r in edfs]
+        run_nrs = [r.split('run-')[1][0:1] for r in edfs]
+        aliases = []
+        for i in range(len(session_nrs)):
+            aliases.append('{}_{}_{}'.format(task, session_nrs[i], run_nrs[i]))
     
         # preprocessing:
-        preprocess_edfs(subject=subject, task=task, edfs=edfs, output_dir=os.path.join(output_dir,task,subject))
-        
-def preprocess_edfs(subject, task, edfs, output_dir):
-    """import_all_data loops across the aliases of the sessions and converts the respective edf files, adds them to the self.ho's hdf5 file. """
-    
-    # folder hierarchy:
-    try:
-        os.makedirs(os.path.join(output_dir, 'raw'))
-    except OSError:
-        pass
-    
-    # hdf5 filename:
-    hdf5_filename = os.path.join(output_dir, '{}_{}.hdf5'.format(subject, task))
-    try:
-        os.remove(hdf5_filename)
-    except OSError:
-        pass
-    
-    # initialize hdf5 HDFEyeOperator:
-    ho = hedfpy.HDFEyeOperator(hdf5_filename)
-    
-    # variables:
-    session_nrs = [r.split('ses-')[1][0:2] for r in edfs]
-    run_nrs = [r.split('run-')[1][0:1] for r in edfs]
-    aliases = []
-    for i in range(len(session_nrs)):
-        aliases.append('{}_{}_{}'.format(task, session_nrs[i], run_nrs[i]))
-    
-    # preprocessing:
-    for (edf_file, alias,) in zip(edfs, aliases):
-        os.system('cp "' + edf_file + '" "' + os.path.join(output_dir, 'raw', alias + '.edf"'))
-    for alias in aliases:
-        ho.add_edf_file(os.path.join(output_dir, 'raw', alias + '.edf'))
-        ho.edf_message_data_to_hdf(alias=alias)
-        ho.edf_gaze_data_to_hdf(alias=alias)
+        for edf_file, alias in zip(edfs, aliases):
+            os.system('cp "' + edf_file + '" "' + os.path.join(output_dir, 'raw', alias + '.edf"'))
+            ho.add_edf_file(os.path.join(output_dir, 'raw', alias + '.edf'))
+            ho.edf_message_data_to_hdf(alias=alias)
+            ho.edf_gaze_data_to_hdf(alias=alias,
+                                    pupil_hp=analysis_params['hp'],
+                                    pupil_lp=analysis_params['lp'],
+                                    normalization=analysis_params['normalization']
+                                    )
 
 def main():
-    preprocess_subjects(subjects)
+    preprocess_subjects(subjects=subjects, task=task, output_dir=output_dir, analysis_params=analysis_params)
 
 if __name__ == '__main__':
     main()

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -10,13 +10,16 @@ task = 'yesno'
 raw_dir = 'raw/'
 output_dir = os.path.expanduser('~/Downloads/pupil_prep/')
 analysis_params = {
+                'sample_rate' : 500.0,
                 'lp' : 6.0,
                 'hp' : 0.01,
                 'normalization' : 'psc',
+                'regress_blinks' : True,
+                'regress_sacs' : True,
                 }
 subjects = [
-            # 'sub-01',
-            'sub-02',
+            'sub-01',
+            # 'sub-02',
             ]
 
 def preprocess_subjects(subjects, task, output_dir, analysis_params):
@@ -57,9 +60,12 @@ def preprocess_subjects(subjects, task, output_dir, analysis_params):
             ho.add_edf_file(os.path.join(preprocess_dir, 'raw', alias + '.edf'))
             ho.edf_message_data_to_hdf(alias=alias)
             ho.edf_gaze_data_to_hdf(alias=alias,
+                                    sample_rate=analysis_params['sample_rate'],
                                     pupil_lp=analysis_params['lp'],
                                     pupil_hp=analysis_params['hp'],
-                                    normalization=analysis_params['normalization']
+                                    normalization=analysis_params['normalization'],
+                                    regress_blinks=analysis_params['regress_blinks'],
+                                    regress_sacs=analysis_params['regress_sacs'],
                                     )
 
 def main():

--- a/example/pupil_preprocessing.py
+++ b/example/pupil_preprocessing.py
@@ -16,6 +16,7 @@ analysis_params = {
                 'normalization' : 'psc',
                 'regress_blinks' : True,
                 'regress_sacs' : True,
+                'regress_xy' : False,
                 'use_standard_blinksac_kernels' : False,
                 }
 subjects = [

--- a/src/CommandLineOperator.py
+++ b/src/CommandLineOperator.py
@@ -10,99 +10,100 @@ Copyright (c) 2010 __MyCompanyName__. All rights reserved.
 import os, sys, subprocess, shutil
 import tempfile, logging
 import re
-
 import scipy as sp
 import numpy as np
 import matplotlib.pylab as pl
+from IPython import embed as shell
 
 from Operator import *
 from log import *
 
-from IPython import embed as shell
-
 ### Execute program in shell:
 def ExecCommandLine(cmdline):
-	tmpf = tempfile.TemporaryFile()
-	try:
-		retcode = subprocess.call( cmdline, shell=True, bufsize=0, stdout = tmpf, stderr = tmpf)
-	finally:
-		tmpf.close()
-		if retcode > 0:
-			raise ValueError( 'Process: '+cmdline+' returned error code: '+str(retcode) )
-	return retcode
+    tmpf = tempfile.TemporaryFile()
+    try:
+        retcode = subprocess.call( cmdline, shell=True, bufsize=0, stdout = tmpf, stderr = tmpf)
+    finally:
+        tmpf.close()
+        if retcode > 0:
+            raise ValueError( 'Process: '+cmdline+' returned error code: '+str(retcode) )
+    return retcode
 
 class CommandLineOperator( Operator ):
-	def __init__(self, input_object, cmd, **kwargs):
-		"""
-		CommandLineOperator can take a Nii file as input but will use only the variable input_file_name
-		"""
-		super(CommandLineOperator, self).__init__(input_object = input_object, **kwargs)
+    def __init__(self, input_object, cmd, **kwargs):
+        """
+        CommandLineOperator can take a Nii file as input but will use only the variable input_file_name
+        """
+        super(CommandLineOperator, self).__init__(input_object = input_object, **kwargs)
 
-		if self.input_object.__class__.__name__ == 'NiftiImage':
-			self.input_file_name = self.input_object.filename
-			self.logger.info(self.__repr__() + ' initialized with ' + os.path.split(self.input_file_name)[-1])
-		elif self.input_object.__class__.__name__ == 'str':
-			self.input_file_name = self.input_object
-			self.logger.info(self.__repr__() + ' initialized with file ' + os.path.split(self.input_file_name)[-1])
-			if not os.path.isfile(self.input_file_name):
-				self.logger.warning('input_file_name is not a file at initialization')
-		elif self.input_object.__class__.__name__ == 'list':
-			self.inputList = self.input_object
-			self.logger.info(self.__repr__() + ' initialized with files ' + str(self.inputList))
-		self.cmd = cmd
+        if self.input_object.__class__.__name__ == 'NiftiImage':
+            self.input_file_name = self.input_object.filename
+            self.logger.info(self.__repr__() + ' initialized with ' + os.path.split(self.input_file_name)[-1])
+        elif self.input_object.__class__.__name__ == 'str':
+            self.input_file_name = self.input_object
+            self.logger.info(self.__repr__() + ' initialized with file ' + os.path.split(self.input_file_name)[-1])
+            if not os.path.isfile(self.input_file_name):
+                self.logger.warning('input_file_name is not a file at initialization')
+        elif self.input_object.__class__.__name__ == 'list':
+            self.inputList = self.input_object
+            self.logger.info(self.__repr__() + ' initialized with files ' + str(self.inputList))
+        self.cmd = cmd
 
-	def configure(self):
-		"""
-		placeholder for configure
-		to be filled in by subclasses
-		"""
-		self.runcmd = self.cmd + ' ' + self.input_file_name
+    def configure(self):
+        """
+        placeholder for configure
+        to be filled in by subclasses
+        """
+        self.runcmd = self.cmd + ' ' + self.input_file_name
 
-	def execute(self, wait = True):
-		"""
-		placeholder for execute
-		to be filled in by subclasses
-		"""
-		self.logger.debug(self.__repr__() + 'executing command \n' + self.runcmd)
-		# print self.runcmd
-		# subprocess.call( self.runcmd, shell=True, bufsize=0, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
-		if not wait:
-			self.runcmd + '&'
-		ExecCommandLine(self.runcmd)
+    def execute(self, wait = True):
+        """
+        placeholder for execute
+        to be filled in by subclasses
+        """
+        self.logger.debug(self.__repr__() + 'executing command \n' + self.runcmd)
+        # print self.runcmd
+        # subprocess.call( self.runcmd, shell=True, bufsize=0, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+        if not wait:
+            self.runcmd + '&'
+        ExecCommandLine(self.runcmd)
 
 class EDF2ASCOperator( CommandLineOperator ):
-	"""
-	EDF2ASCOperator provides the tools to convert an edf file to a pair of output files,
-	one containing the gaze samples (.gaz) and another containing all the messages/events (.msg).
-	It requires edf2asc command-line executable, which is assumed to be on the $PATH.
-	Missing values are imputed as 0.0001, time is represented as a floating point number for 2000Hz sampling.
-	"""
-	def __init__(self, input_object, **kwargs):
-		super(EDF2ASCOperator, self).__init__(input_object = input_object, cmd = 'edf2asc', **kwargs)
+    """
+    EDF2ASCOperator provides the tools to convert an edf file to a pair of output files,
+    one containing the gaze samples (.gaz) and another containing all the messages/events (.msg).
+    It requires edf2asc command-line executable, which is assumed to be on the $PATH.
+    Missing values are imputed as 0.0001, time is represented as a floating point number for 2000Hz sampling.
+    """
+    def __init__(self, input_object, **kwargs):
+        super(EDF2ASCOperator, self).__init__(input_object = input_object, cmd = 'edf2asc', **kwargs)
 
-	def configure(self, gazeOutputFileName = None, messageOutputFileName = None, settings = ' -t -ftime -y -z -v '):
-		"""
-		configure creates commands self.gazcmd and self.msgcmd which,
-		when executed on the command line, convert the edf 2 an asc file,
-		taking either the sample data or the event data, respectively.
-		it also creates self.runcmd which can be used to run both above
-		commands in succession, and which will be executed when calling
-		'execute' (as per CommandLineOperator behavior)
-		"""
-		if gazeOutputFileName == None:
-			self.gazeOutputFileName = os.path.splitext(self.input_file_name)[0] + '.gaz'
-		else:
-			self.gazeOutputFileName = gazeOutputFileName
-		if messageOutputFileName == None:
-			self.messageOutputFileName = os.path.splitext(self.input_file_name)[0] + '.msg'
-		else:
-			self.messageOutputFileName = messageOutputFileName
-		standardOutputFileName = os.path.splitext(self.input_file_name)[0] + '.asc'
+    def configure(self, gazeOutputFileName = None, messageOutputFileName = None, settings = ' -t -ftime -y -z -v '):
+        """
+        configure creates commands self.gazcmd and self.msgcmd which,
+        when executed on the command line, convert the edf 2 an asc file,
+        taking either the sample data or the event data, respectively.
+        it also creates self.runcmd which can be used to run both above
+        commands in succession, and which will be executed when calling
+        'execute' (as per CommandLineOperator behavior)
+        """
+        if gazeOutputFileName == None:
+            self.gazeOutputFileName = os.path.splitext(self.input_file_name)[0] + '.gaz'
+        else:
+            self.gazeOutputFileName = gazeOutputFileName
+        if messageOutputFileName == None:
+            self.messageOutputFileName = os.path.splitext(self.input_file_name)[0] + '.msg'
+        else:
+            self.messageOutputFileName = messageOutputFileName
+        standardOutputFileName = os.path.splitext(self.input_file_name)[0] + '.asc'
 
-		self.intermediatecmd = self.cmd
-		self.intermediatecmd += settings
-
-		self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "'+self.input_file_name+'"; mv ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.gazeOutputFileName.replace('|', '\|') + '"'
-		self.msgcmd = self.intermediatecmd + '-e "'+self.input_file_name+'"; mv ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.messageOutputFileName.replace('|', '\|') + '"'
-
-		self.runcmd = self.gazcmd + '; ' + self.msgcmd
+        self.intermediatecmd = self.cmd
+        self.intermediatecmd += settings
+        
+        if sys.platform.startswith('win')
+            self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "'+self.input_file_name+'"; move ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.gazeOutputFileName.replace('|', '\|') + '"'
+            self.msgcmd = self.intermediatecmd + '-e "'+self.input_file_name+'"; move ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.messageOutputFileName.replace('|', '\|') + '"'
+        else:
+            self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "'+self.input_file_name+'"; mv ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.gazeOutputFileName.replace('|', '\|') + '"'
+            self.msgcmd = self.intermediatecmd + '-e "'+self.input_file_name+'"; mv ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.messageOutputFileName.replace('|', '\|') + '"'
+        self.runcmd = self.gazcmd + '; ' + self.msgcmd

--- a/src/CommandLineOperator.py
+++ b/src/CommandLineOperator.py
@@ -101,9 +101,10 @@ class EDF2ASCOperator( CommandLineOperator ):
         self.intermediatecmd += settings
         
         if sys.platform.startswith('win'):
-            self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "'+self.input_file_name+'"; move ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.gazeOutputFileName.replace('|', '\|') + '"'
-            self.msgcmd = self.intermediatecmd + '-e "'+self.input_file_name+'"; move ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.messageOutputFileName.replace('|', '\|') + '"'
+            self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "{}" & move "{}" "{}"'.format(os.path.normpath(self.input_file_name), os.path.normpath(standardOutputFileName), os.path.normpath(self.gazeOutputFileName))
+            self.msgcmd = self.intermediatecmd + '-e "{}" & move "{}" "{}"'.format(os.path.normpath(self.input_file_name), os.path.normpath(standardOutputFileName), os.path.normpath(self.messageOutputFileName))
+            self.runcmd = self.gazcmd + ' && ' + self.msgcmd
         else:
             self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "'+self.input_file_name+'"; mv ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.gazeOutputFileName.replace('|', '\|') + '"'
             self.msgcmd = self.intermediatecmd + '-e "'+self.input_file_name+'"; mv ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.messageOutputFileName.replace('|', '\|') + '"'
-        self.runcmd = self.gazcmd + '; ' + self.msgcmd
+            self.runcmd = self.gazcmd + '; ' + self.msgcmd

--- a/src/CommandLineOperator.py
+++ b/src/CommandLineOperator.py
@@ -100,7 +100,7 @@ class EDF2ASCOperator( CommandLineOperator ):
         self.intermediatecmd = self.cmd
         self.intermediatecmd += settings
         
-        if sys.platform.startswith('win')
+        if sys.platform.startswith('win'):
             self.gazcmd = self.intermediatecmd + '-s -miss 0.0001 -vel "'+self.input_file_name+'"; move ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.gazeOutputFileName.replace('|', '\|') + '"'
             self.msgcmd = self.intermediatecmd + '-e "'+self.input_file_name+'"; move ' + '"' + standardOutputFileName.replace('|', '\|') + '" "' + self.messageOutputFileName.replace('|', '\|') + '"'
         else:

--- a/src/EDFOperator.py
+++ b/src/EDFOperator.py
@@ -25,405 +25,405 @@ from Operator import Operator
 from IPython import embed as shell
 
 class EDFOperator( Operator ):     
-	"""
-	upon initialization, EDFOperator creates an EDF2ASCOperator that sets up 
-	the edf to asc conversion of self.inputFileObject, and immediately
-	executes the conversion.
-	"""     
-	def __init__(self, input_object, **kwargs):         
-		super(EDFOperator, self).__init__(input_object = input_object, **kwargs)         
-		if self.input_object.__class__.__name__ == 'str':             
-			self.input_file_name = self.input_object         
-			self.logger.info('started with '+os.path.split(self.input_file_name)[-1])
-		
-		# ** DATE: Tue Feb  4 10:19:06 2014
-		if os.path.splitext(self.input_object)[-1] == '.edf':
-			self.input_file_name = self.input_object
-			# in Kwargs there's a variable that we can set to 
-			eac = EDF2ASCOperator(self.input_file_name)
-			eac.configure()
-			self.message_file = eac.messageOutputFileName
-			self.gaze_file = eac.gazeOutputFileName
-			if not os.path.isfile(eac.messageOutputFileName):
-				eac.execute()
-		else:
-			self.logger.error('input file has to be of edf type.')
-	
-	def clean_gaze_information(self):
-		"""
-		clean_gaze_information takes out non-numeric signs from the gaze data file,
-		stores the non-cleaned data in a zipped version of the file (.gz)
-		and stores the clean data under the original, non-zipped file name
-		"""
-		
-		self.logger.info('cleaning gaze information from %s'%self.gaze_file)
-		if os.path.isfile(self.gaze_file + '.gz'):
-			self.logger.error('gaze information already cleaned')
-			return
-		
-		with open(self.gaze_file, 'r') as f:
-			gaze_string = f.read()
-		
-		# optimize this so that it doesn't delete the periods in the float time, for example.
-		# first clean out those C and R occurrences. No letters allowed.
-		gaze_string = re.sub(re.compile('[A-Z]+'), '', gaze_string)
-		gaze_string = re.sub(re.compile('\t+\.+'), '', gaze_string)
-		# # check for these really weird character shit in the final columns of the output.
-		# self.workingStringClean = re.sub(re.compile('C.'), '', self.workingStringClean)
-		
-		# compress the older, non-clean, gaze file
-		os.system('gzip "' + self.gaze_file + '"')
-		
-		of = open(self.gaze_file, 'w')
-		of.write(gaze_string)
-		of.close()
-	
-	def get_message_string(self):
-		"""message_data loads the message data into an internal string variable"""
-		if not hasattr(self, 'message_string'):
-			with open(self.message_file, 'r') as mfd:
-				self.message_string = mfd.read()
-	
-	def read_session_information(self):
-		"""
-		read_session_information takes the message file and reads the information pertaining to this session.
-		this information is then stored in this operator's internal variables.
-		"""
-		self.logger.info('reading session information from %s'%self.message_file)
-		
-		with open(self.message_file, 'r') as mfd:
-			self.header = ''.join([mfd.next() for x in xrange(10)])
-		date_string = ' '.join([h for h in self.header.split('\n')[1].split(' ') if h not in ('', '**', 'DATE:')][1:])
-		self.recording_datetime = datetime.strptime(date_string, "%b %d %H:%M:%S %Y") # %a 
-		
-		self.logger.info(self.header)
-		
-	
-	def identify_blocks(self, minimal_time_gap = 50.0, minimal_block_duration = 30e3):
-		"""
-		identify separate recording blocks in eyelink file, where 'blocks' means periods between
-		startrecording and stoprecording
-		
-		identify_blocks looks into the gaze file and searches for discontinuities in the sample times of at least minimal_time_gap milliseconds. 
-		The message file is used to look at the recorded eyes and samplerate per discontinuous block.
-		The resulting internal variable is self.blocks, which is a dictionary that specifies the characteristics of each of the encountered blocks,
-		but not the sample data itself, which will remain accessable via self.gaze_file and is added to self.blocks later (see take_gaze_data_for_blocks).
+    """
+    upon initialization, EDFOperator creates an EDF2ASCOperator that sets up 
+    the edf to asc conversion of self.inputFileObject, and immediately
+    executes the conversion.
+    """     
+    def __init__(self, input_object, **kwargs):         
+        super(EDFOperator, self).__init__(input_object = input_object, **kwargs)         
+        if self.input_object.__class__.__name__ == 'str':             
+            self.input_file_name = self.input_object         
+            self.logger.info('started with '+os.path.split(self.input_file_name)[-1])
+        
+        # ** DATE: Tue Feb  4 10:19:06 2014
+        if os.path.splitext(self.input_object)[-1] == '.edf':
+            self.input_file_name = self.input_object
+            # in Kwargs there's a variable that we can set to 
+            eac = EDF2ASCOperator(self.input_file_name)
+            eac.configure()
+            self.message_file = eac.messageOutputFileName
+            self.gaze_file = eac.gazeOutputFileName
+            if not os.path.isfile(eac.messageOutputFileName):
+                eac.execute()
+        else:
+            self.logger.error('input file has to be of edf type.')
+    
+    def clean_gaze_information(self):
+        """
+        clean_gaze_information takes out non-numeric signs from the gaze data file,
+        stores the non-cleaned data in a zipped version of the file (.gz)
+        and stores the clean data under the original, non-zipped file name
+        """
+        
+        self.logger.info('cleaning gaze information from %s'%self.gaze_file)
+        if os.path.isfile(self.gaze_file + '.gz'):
+            self.logger.error('gaze information already cleaned')
+            return
+        
+        with open(self.gaze_file, 'r') as f:
+            gaze_string = f.read()
+        
+        # optimize this so that it doesn't delete the periods in the float time, for example.
+        # first clean out those C and R occurrences. No letters allowed.
+        gaze_string = re.sub(re.compile('[A-Z]+'), '', gaze_string)
+        gaze_string = re.sub(re.compile('\t+\.+'), '', gaze_string)
+        # # check for these really weird character shit in the final columns of the output.
+        # self.workingStringClean = re.sub(re.compile('C.'), '', self.workingStringClean)
+        
+        # compress the older, non-clean, gaze file
+        os.system('gzip "' + self.gaze_file + '"')
+        
+        of = open(self.gaze_file, 'w')
+        of.write(gaze_string)
+        of.close()
+    
+    def get_message_string(self):
+        """message_data loads the message data into an internal string variable"""
+        if not hasattr(self, 'message_string'):
+            with open(self.message_file, 'r') as mfd:
+                self.message_string = mfd.read()
+    
+    def read_session_information(self):
+        """
+        read_session_information takes the message file and reads the information pertaining to this session.
+        this information is then stored in this operator's internal variables.
+        """
+        self.logger.info('reading session information from %s'%self.message_file)
+        
+        with open(self.message_file, 'r') as mfd:
+            self.header = ''.join([mfd.next() for x in xrange(10)])
+        date_string = ' '.join([h for h in self.header.split('\n')[1].split(' ') if h not in ('', '**', 'DATE:')][1:])
+        self.recording_datetime = datetime.strptime(date_string, "%b %d %H:%M:%S %Y") # %a 
+        
+        self.logger.info(self.header)
+        
+    
+    def identify_blocks(self, minimal_time_gap = 50.0, minimal_block_duration = 30e3):
+        """
+        identify separate recording blocks in eyelink file, where 'blocks' means periods between
+        startrecording and stoprecording
+        
+        identify_blocks looks into the gaze file and searches for discontinuities in the sample times of at least minimal_time_gap milliseconds. 
+        The message file is used to look at the recorded eyes and samplerate per discontinuous block.
+        The resulting internal variable is self.blocks, which is a dictionary that specifies the characteristics of each of the encountered blocks,
+        but not the sample data itself, which will remain accessable via self.gaze_file and is added to self.blocks later (see take_gaze_data_for_blocks).
 
-		Only blocks with a duration larger than minimal_block_duration (in ms) will be selected. 
-		"""
-		self.logger.info('identifying recording blocks from %s'%self.gaze_file)
-		# check whether the gaze data has been cleaned up
-		if not os.path.isfile(self.gaze_file + '.gz'):
-			self.logger.error('gaze information not cleaned before running block identification')
-			self.clean_gaze_information()
-			pass
-		
-		gaze_times = np.loadtxt(self.gaze_file, usecols = (0,))
-		block_edge_indices = np.array([np.arange(gaze_times.shape[0])[np.roll(np.r_[True,np.diff(gaze_times) > minimal_time_gap], 0)], 										
-			np.arange(gaze_times.shape[0])[np.roll(np.r_[True,np.diff(gaze_times) > minimal_time_gap], -1)]]).T
-		block_edge_times = [gaze_times[i] for i in block_edge_indices]
-		
-		self.get_message_string()
-		sample_re = 'MSG\t[\d\.]+\t!MODE RECORD CR (\d+) \d+ \d+ (\S+)'
-		block_sample_occurrences = re.findall(re.compile(sample_re), self.message_string)
-		
-		screen_re = 'MSG\t[\d\.]+\tGAZE_COORDS (\d+.\d+) (\d+.\d+) (\d+.\d+) (\d+.\d+)'
-		block_screen_occurrences = re.findall(re.compile(screen_re), self.message_string)
-		
-		self.blocks = [{'block_start_index': h[0], 'block_end_index': h[1], 
-						'block_start_timestamp': i[0], 'block_end_timestamp': i[1], 
-						'sample_rate': int(j[0]), 'eye_recorded': j[1], 
-						'screen_x_pix': float(k[2])-float(k[0]), 'screen_y_pix': float(k[3])-float(k[1]),  }
-					for h,i,j,k in zip(block_edge_indices, block_edge_times, block_sample_occurrences, block_screen_occurrences)]
-		
-		self.logger.info('%i raw blocks discovered' % len(self.blocks))
-		# select only blocks of a significant duration, assuming timestamps in ms
-		selected_block_indices = []
-		for i, b in enumerate(self.blocks):
-			minimal_block_duration_samples = minimal_block_duration * b['sample_rate'] / 1000.0
-			self.logger.info('%f raw block duration, threshold %f' % (b['block_end_timestamp'] - b['block_start_timestamp'], minimal_block_duration_samples))
-			if (b['block_end_timestamp'] - b['block_start_timestamp']) > minimal_block_duration_samples:
-				selected_block_indices.append(i)
-		# and perform selection
-		self.blocks = [self.blocks[i] for i in selected_block_indices]
+        Only blocks with a duration larger than minimal_block_duration (in ms) will be selected. 
+        """
+        self.logger.info('identifying recording blocks from %s'%self.gaze_file)
+        # check whether the gaze data has been cleaned up
+        if not os.path.isfile(self.gaze_file + '.gz'):
+            self.logger.error('gaze information not cleaned before running block identification')
+            self.clean_gaze_information()
+            pass
+        
+        gaze_times = np.loadtxt(self.gaze_file, usecols = (0,))
+        block_edge_indices = np.array([np.arange(gaze_times.shape[0])[np.roll(np.r_[True,np.diff(gaze_times) > minimal_time_gap], 0)],                                         
+            np.arange(gaze_times.shape[0])[np.roll(np.r_[True,np.diff(gaze_times) > minimal_time_gap], -1)]]).T
+        block_edge_times = [gaze_times[i] for i in block_edge_indices]
+        
+        self.get_message_string()
+        sample_re = 'MSG\t[\d\.]+\t!MODE RECORD CR (\d+) \d+ \d+ (\S+)'
+        block_sample_occurrences = re.findall(re.compile(sample_re), self.message_string)
+        
+        screen_re = 'MSG\t[\d\.]+\tGAZE_COORDS (\d+.\d+) (\d+.\d+) (\d+.\d+) (\d+.\d+)'
+        block_screen_occurrences = re.findall(re.compile(screen_re), self.message_string)
+        
+        self.blocks = [{'block_start_index': h[0], 'block_end_index': h[1], 
+                        'block_start_timestamp': i[0], 'block_end_timestamp': i[1], 
+                        'sample_rate': int(j[0]), 'eye_recorded': j[1], 
+                        'screen_x_pix': float(k[2])-float(k[0]), 'screen_y_pix': float(k[3])-float(k[1]),  }
+                    for h,i,j,k in zip(block_edge_indices, block_edge_times, block_sample_occurrences, block_screen_occurrences)]
+        
+        self.logger.info('%i raw blocks discovered' % len(self.blocks))
+        # select only blocks of a significant duration, assuming timestamps in ms
+        selected_block_indices = []
+        for i, b in enumerate(self.blocks):
+            minimal_block_duration_samples = minimal_block_duration * b['sample_rate'] / 1000.0
+            self.logger.info('%f raw block duration, threshold %f' % (b['block_end_timestamp'] - b['block_start_timestamp'], minimal_block_duration_samples))
+            if (b['block_end_timestamp'] - b['block_start_timestamp']) > minimal_block_duration_samples:
+                selected_block_indices.append(i)
+        # and perform selection
+        self.blocks = [self.blocks[i] for i in selected_block_indices]
 
-		# now, we know what the different columns must mean per block, so we can create them
-		for bl in self.blocks:
-			if bl['eye_recorded'] == 'LR':
-				bl.update({'data_columns': ['time','L_gaze_x','L_gaze_y','L_pupil','R_gaze_x','R_gaze_y','R_pupil','L_vel_x','L_vel_y','R_vel_x','R_vel_y']})
-			elif bl['eye_recorded'] == 'R':
-				bl.update({'data_columns': ['time','R_gaze_x','R_gaze_y','R_pupil','R_vel_x','R_vel_y']})
-			elif bl['eye_recorded'] == 'L':
-				bl.update({'data_columns': ['time','L_gaze_x','L_gaze_y','L_pupil','L_vel_x','L_vel_y']})
-		
-		self.logger.info('%i correct duration blocks discovered' % len(self.blocks))
-		
-	
-	def read_all_messages(self):
-		"""
-		read_all_messages reads the messages sent to the eyelink by the experiment computer.
-		
-		it does this with all of the different types of information that can be listed in a message file.
-		read_all_messages works independently of the identify_blocks method.
-		
-		read_all_messages counts on messages in particular formats having been sent to the eyelink during the experiment.
-		The defaults are as follows (where X=trial number):
-		Start of a trial: 'MSG\t([\d\.]+)\ttrial (\d+) started at (\d+.\d)'
-		End of a trial: 'MSG\t([\d\.]+)\ttrial (\d+) stopped at (\d+.\d)'
-		Start of a phase within a trial: 'MSG\t([\d\.]+)\ttrial X phase (\d+) started at (\d+.\d)'
-		Parameters that may vary per trial: 'MSG\t[\d\.]+\ttrial X parameter[\t ]*(\S*?)\s+: ([-\d\.]*|[\w]*)'
-		Keys that may have been pressed within a trial:
-		'MSG\t([\d\.]+)\ttrial X event \<Event\((\d)-Key(\S*?) {\'scancode\': (\d+), \'key\': (\d+)(, \'unicode\': u\'\S*?\',|,) \'mod\': (\d+)}\)\> at (\d+.\d)'
-		Sound events: 'MSG\t([\d\.]+)\treward (\d+) at (\d+.\d)'
-		
-		These messages can be customized, but the code does expect these to be regular
-		expressions that return the numbers and strings that these REs do (i.e. parts between []).
-		
-		read_all_messages also counts on further info that is automatically included in the edf event data,
-		so there is no need to send it to Eyelink yourself:
-		Saccade info:
-		'ESACC\t(\S+)[\s\t]+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+.?\d+)', 
-		Fixation info: 'EFIX\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?', 
-		Blink info: 'EBLINK\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d?.?\d*)?'
-		"""
-		
-		self.get_message_string()	#loads the entire message file into an internal variable self.message_string
-		self.read_trials()
-		self.read_key_events()
-		self.read_eyelink_events()
-		self.read_sound_events()
-	
-	def read_trials(self, 
-		start_re = 'MSG\t([\d\.]+)\ttrial (\d+) started at (\d+.\d)', 
-		stop_re = 'MSG\t([\d\.]+)\ttrial (\d+) stopped at (\d+.\d)', 
-		phase_re = 'MSG\t([\d\.]+)\ttrial X phase (\d+) started at (\d+.\d)',
-		parameter_re = 'MSG\t[\d\.]+\ttrial X parameter[\t ]*(\S*?)\s+: ([-\d\.]*|[\w]*)'):
-		
-		"""
-		read_trials reads in trials from the message file,
-		constructing timings and parameters for each of the trials,
-		their phases and their parameters.
-		It reads the actual values to internal variables, and also 
-		creates dictionaries that will indicate the formats needed
-		when creating the hfd5 file
-		"""
-		
-		self.logger.info('reading trials from %s', os.path.split(self.message_file)[-1])
-		self.get_message_string()
-		
-		#
-		# read the trials themselves
-		#
-		self.start_trial_strings = re.findall(re.compile(start_re), self.message_string)
-		self.stop_trial_strings = re.findall(re.compile(stop_re), self.message_string)
-		
-		if len(self.start_trial_strings) > 0:	# check whether there are any trials here. 
-			
-			self.trial_starts = np.array([[float(s[0]), int(s[1]), float(s[2])] for s in self.start_trial_strings])
-			self.trial_ends = np.array([[float(s[0]), int(s[1]), float(s[2])] for s in self.stop_trial_strings])
-			
-			# sometimes we have twice as many trial starts as trial ends!
-			if 2 * len(self.trial_starts) == len(self.trial_ends):
-				self.trial_ends = self.trial_ends[::2]
-			
-			# due to early task abortion we can have more trial starts than trial ends:
-			if abs(len(self.trial_starts) - len(self.trial_ends)) == 1:
-				self.trial_starts = self.trial_starts[:-2]
-				self.trial_ends = self.trial_ends[:len(self.trial_starts)]
-			
-			self.nr_trials = len(self.trial_starts)
-			self.trials = np.hstack((self.trial_starts, self.trial_ends))
-			
-			# create a dictionary for the types of timing informations we'd like to look at
-			self.trial_type_dictionary = [('trial_start_EL_timestamp', np.float64), ('trial_start_index',np.int32), ('trial_start_exp_timestamp',np.float64), ('trial_end_EL_timestamp',np.float64), ('trial_end_index',np.int32), ('trial_end_exp_timestamp',np.float64)]
-			
-			self.trials = [{'trial_start_EL_timestamp': tr[0], 'trial_start_index': tr[1], 'trial_start_exp_timestamp': tr[2], 'trial_end_EL_timestamp': tr[3], 'trial_end_index': tr[4], 'trial_end_exp_timestamp': tr[5]} for tr in self.trials]
-			
-			self.trial_type_dictionary = np.dtype(self.trial_type_dictionary)
-			#
-			# trial phases 
-			#
-			self.trial_phases = []
-			for i in range(self.nr_trials):
-				this_trial_re = phase_re.replace(' X ', ' ' + str(i) + ' ')
-				phase_strings = re.findall(re.compile(this_trial_re), self.message_string)
-				self.trial_phases.append([[int(i), float(s[0]), int(s[1]), float(s[2])] for s in phase_strings])
-			self.trial_phases = list(chain.from_iterable(self.trial_phases))
-			self.trial_phases = [{'trial_phase_trial': tr[0], 'trial_phase_EL_timestamp': tr[1], 'trial_phase_index': tr[2], 'trial_phase_exp_timestamp': tr[3]} for tr in self.trial_phases]
-			self.nr_trial_phases = len(self.trial_phases)
-			
-			self.trial_phase_type_dictionary = [('trial_phase_trial', np.float64), ('trial_phase_EL_timestamp',np.int32), ('trial_phase_index',np.float64), ('trial_phase_exp_timestamp',np.float64)]
-			self.trial_phase_type_dictionary = np.dtype(self.trial_phase_type_dictionary)
-			
-			# now adjust the trial type dictionary and convert into a numpy dtype
-			# self.trial_type_dictionary.append(('trial_phase_timestamps', np.float64, (self.nr_phase_starts.max(), 3)))
-		else:
-			self.logger.info('no trial or phase information in edf file %s'%self.input_file_name)
-			self.nr_trials = 0
-		
-		#
-		# parameters 
-		#
-		
-		self.message_string = self.message_string.replace(' [','').replace('.]','')
-		
-		parameters = []
-		for i in range(self.nr_trials):
-			this_re = parameter_re.replace(' X ', ' ' + str(i) + ' ')
-			parameter_strings = re.findall(re.compile(this_re), self.message_string)
-			
-			# check if double params:
-			param_names = np.array([p[0] for p in parameter_strings])
-			try:
-				nr_double_trials = sum(param_names == param_names[0])
-			
-				# we have double trials -- custom procedure!:
-				if nr_double_trials > 1:
-					nr_params = len(param_names) / nr_double_trials
-					nr_param = 0
-					parameter_strings2 = []
-					for d in range(nr_double_trials):
-						parameter_strings2.append( parameter_strings[nr_param:nr_param+nr_params] )
-						nr_param += nr_params
-					for d in parameter_strings2:
-						# assuming all these parameters are numeric
-						this_trial_parameters = {'trial_nr': float(i)}
-						for s in d:
-							try:
-								this_trial_parameters.update({s[0]: float(s[1])})
-							except ValueError:
-								pass
-						parameters.append(this_trial_parameters)
-				
-				# we don't have double trial -- standard procedure!
-				else:
-					if len(parameter_strings) > 0:
-						# assuming all these parameters are numeric
-						this_trial_parameters = {'trial_nr': float(i)}
-						for s in parameter_strings:
-							try:
-								this_trial_parameters.update({s[0]: float(s[1])})
-							except ValueError:
-								pass
-						parameters.append(this_trial_parameters)
-			except:
-				pass
-		
-		if len(parameters) > 0:		# there were parameters in the edf file
-			self.parameters = parameters
-			print([k.keys() for k in self.parameters])
-			ptd = [(k, np.float64) for k in set(self.parameters[0].keys())]
-			self.parameter_type_dictionary = np.dtype(ptd)
-		else: # we have to take the parameters from the output_dict pickle file of the same name as the edf file. 
-			self.logger.info('no parameter information in edf file')
-			
-	
-	def read_key_events(self, 
-		key_re = 'MSG\t([\d\.]+)\ttrial X event \<Event\((\d)-Key(\S*?) {\'scancode\': (\d+), \'key\': (\d+)(, \'unicode\': u\'\S*?\',|,) \'mod\': (\d+)}\)\> at (\d+.\d)'):
-		"""read_key_events reads experimental events from the message file"""
-		self.logger.info('reading key_events from %s', os.path.split(self.message_file)[-1])
-		self.get_message_string()
-		if not hasattr(self, 'nr_trials'):
-			self.read_trials()
-		
-		events = []
-		this_length = 0
-		for i in range(self.nr_trials):
-			this_key_re = key_re.replace(' X ', ' ' + str(i) + ' ')
-			event_strings = re.findall(re.compile(this_key_re), self.message_string)
-			if len(event_strings) > 0:
-				if len(event_strings[0]) == 8:
-					events.append([{'EL_timestamp':float(e[0]),'event_type':int(e[1]),'up_down':e[2],'scancode':int(e[3]),'key':int(e[4]),'modifier':int(e[6]), 'exp_timestamp':float(e[7])} for e in event_strings])
-					this_length = 8
-				elif len(event_strings[0]) == 3:
-					events.append([{'EL_timestamp':float(e[0]),'event_type':int(e[1]), 'exp_timestamp':float(e[2])} for e in event_strings])
-					this_length = 3
-		if len(events) > 0:
-			self.events = list(chain.from_iterable(events))
-			#
-			# add types to eventTypeDictionary that specify the relevant trial and time in trial for this event - per run.
-			#
-			if this_length == 8:
-				self.event_type_dictionary = np.dtype([('EL_timestamp', np.float64), ('event_type', np.float64), ('up_down', '|S25'), ('scancode', np.float64), ('key', np.float64), ('modifier', np.float64), ('exp_timestamp', np.float64)])
-			elif this_length == 3:
-				self.event_type_dictionary = np.dtype([('EL_timestamp', np.float64), ('event_type', np.float64), ('exp_timestamp', np.float64)])
-	
-	def read_eyelink_events(self,
-		sacc_re = 'ESACC\t(\S+)[\s\t]+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+.?\d+)',
-		fix_re = 'EFIX\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?', 
-		blink_re = 'EBLINK\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d?.?\d*)?'):
-		"""
-		read_key_events reads experimental events from the message file. 
-		
-		other sacc_re = 'ESACC\t(\S+)[\s\t]+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+.?\d+)', 
+        # now, we know what the different columns must mean per block, so we can create them
+        for bl in self.blocks:
+            if bl['eye_recorded'] == 'LR':
+                bl.update({'data_columns': ['time','L_gaze_x','L_gaze_y','L_pupil','R_gaze_x','R_gaze_y','R_pupil','L_vel_x','L_vel_y','R_vel_x','R_vel_y']})
+            elif bl['eye_recorded'] == 'R':
+                bl.update({'data_columns': ['time','R_gaze_x','R_gaze_y','R_pupil','R_vel_x','R_vel_y']})
+            elif bl['eye_recorded'] == 'L':
+                bl.update({'data_columns': ['time','L_gaze_x','L_gaze_y','L_pupil','L_vel_x','L_vel_y']})
+        
+        self.logger.info('%i correct duration blocks discovered' % len(self.blocks))
+        
+    
+    def read_all_messages(self):
+        """
+        read_all_messages reads the messages sent to the eyelink by the experiment computer.
+        
+        it does this with all of the different types of information that can be listed in a message file.
+        read_all_messages works independently of the identify_blocks method.
+        
+        read_all_messages counts on messages in particular formats having been sent to the eyelink during the experiment.
+        The defaults are as follows (where X=trial number):
+        Start of a trial: 'MSG\t([\d\.]+)\ttrial (\d+) started at (\d+.\d)'
+        End of a trial: 'MSG\t([\d\.]+)\ttrial (\d+) stopped at (\d+.\d)'
+        Start of a phase within a trial: 'MSG\t([\d\.]+)\ttrial X phase (\d+) started at (\d+.\d)'
+        Parameters that may vary per trial: 'MSG\t[\d\.]+\ttrial X parameter[\t ]*(\S*?)\s+: ([-\d\.]*|[\w]*)'
+        Keys that may have been pressed within a trial:
+        'MSG\t([\d\.]+)\ttrial X event \<Event\((\d)-Key(\S*?) {\'scancode\': (\d+), \'key\': (\d+)(, \'unicode\': u\'\S*?\',|,) \'mod\': (\d+)}\)\> at (\d+.\d)'
+        Sound events: 'MSG\t([\d\.]+)\treward (\d+) at (\d+.\d)'
+        
+        These messages can be customized, but the code does expect these to be regular
+        expressions that return the numbers and strings that these REs do (i.e. parts between []).
+        
+        read_all_messages also counts on further info that is automatically included in the edf event data,
+        so there is no need to send it to Eyelink yourself:
+        Saccade info:
+        'ESACC\t(\S+)[\s\t]+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+.?\d+)', 
+        Fixation info: 'EFIX\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?', 
+        Blink info: 'EBLINK\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d?.?\d*)?'
+        """
+        
+        self.get_message_string()    #loads the entire message file into an internal variable self.message_string
+        self.read_trials()
+        self.read_key_events()
+        self.read_eyelink_events()
+        self.read_sound_events()
+    
+    def read_trials(self, 
+        start_re = 'MSG\t([\d\.]+)\ttrial (\d+) started at (\d+.\d)', 
+        stop_re = 'MSG\t([\d\.]+)\ttrial (\d+) stopped at (\d+.\d)', 
+        phase_re = 'MSG\t([\d\.]+)\ttrial X phase (\d+) started at (\d+.\d)',
+        parameter_re = 'MSG\t[\d\.]+\ttrial X parameter[\t ]*(\S*?)\s+: ([-\d\.]*|[\w]*)'):
+        
+        """
+        read_trials reads in trials from the message file,
+        constructing timings and parameters for each of the trials,
+        their phases and their parameters.
+        It reads the actual values to internal variables, and also 
+        creates dictionaries that will indicate the formats needed
+        when creating the hfd5 file
+        """
+        
+        self.logger.info('reading trials from %s', os.path.split(self.message_file)[-1])
+        self.get_message_string()
+        
+        #
+        # read the trials themselves
+        #
+        self.start_trial_strings = re.findall(re.compile(start_re), self.message_string)
+        self.stop_trial_strings = re.findall(re.compile(stop_re), self.message_string)
+        
+        if len(self.start_trial_strings) > 0:    # check whether there are any trials here. 
+            
+            self.trial_starts = np.array([[float(s[0]), int(s[1]), float(s[2])] for s in self.start_trial_strings])
+            self.trial_ends = np.array([[float(s[0]), int(s[1]), float(s[2])] for s in self.stop_trial_strings])
+            
+            # sometimes we have twice as many trial starts as trial ends!
+            if 2 * len(self.trial_starts) == len(self.trial_ends):
+                self.trial_ends = self.trial_ends[::2]
+            
+            # due to early task abortion we can have more trial starts than trial ends:
+            if abs(len(self.trial_starts) - len(self.trial_ends)) == 1:
+                self.trial_starts = self.trial_starts[:-2]
+                self.trial_ends = self.trial_ends[:len(self.trial_starts)]
+            
+            self.nr_trials = len(self.trial_starts)
+            self.trials = np.hstack((self.trial_starts, self.trial_ends))
+            
+            # create a dictionary for the types of timing informations we'd like to look at
+            self.trial_type_dictionary = [('trial_start_EL_timestamp', np.float64), ('trial_start_index',np.int32), ('trial_start_exp_timestamp',np.float64), ('trial_end_EL_timestamp',np.float64), ('trial_end_index',np.int32), ('trial_end_exp_timestamp',np.float64)]
+            
+            self.trials = [{'trial_start_EL_timestamp': tr[0], 'trial_start_index': tr[1], 'trial_start_exp_timestamp': tr[2], 'trial_end_EL_timestamp': tr[3], 'trial_end_index': tr[4], 'trial_end_exp_timestamp': tr[5]} for tr in self.trials]
+            
+            self.trial_type_dictionary = np.dtype(self.trial_type_dictionary)
+            #
+            # trial phases 
+            #
+            self.trial_phases = []
+            for i in range(self.nr_trials):
+                this_trial_re = phase_re.replace(' X ', ' ' + str(i) + ' ')
+                phase_strings = re.findall(re.compile(this_trial_re), self.message_string)
+                self.trial_phases.append([[int(i), float(s[0]), int(s[1]), float(s[2])] for s in phase_strings])
+            self.trial_phases = list(chain.from_iterable(self.trial_phases))
+            self.trial_phases = [{'trial_phase_trial': tr[0], 'trial_phase_EL_timestamp': tr[1], 'trial_phase_index': tr[2], 'trial_phase_exp_timestamp': tr[3]} for tr in self.trial_phases]
+            self.nr_trial_phases = len(self.trial_phases)
+            
+            self.trial_phase_type_dictionary = [('trial_phase_trial', np.float64), ('trial_phase_EL_timestamp',np.int32), ('trial_phase_index',np.float64), ('trial_phase_exp_timestamp',np.float64)]
+            self.trial_phase_type_dictionary = np.dtype(self.trial_phase_type_dictionary)
+            
+            # now adjust the trial type dictionary and convert into a numpy dtype
+            # self.trial_type_dictionary.append(('trial_phase_timestamps', np.float64, (self.nr_phase_starts.max(), 3)))
+        else:
+            self.logger.info('no trial or phase information in edf file %s'%self.input_file_name)
+            self.nr_trials = 0
+        
+        #
+        # parameters 
+        #
+        
+        self.message_string = self.message_string.replace(' [','').replace('.]','')
+        
+        parameters = []
+        for i in range(self.nr_trials):
+            this_re = parameter_re.replace(' X ', ' ' + str(i) + ' ')
+            parameter_strings = re.findall(re.compile(this_re), self.message_string)
+            
+            # check if double params:
+            param_names = np.array([p[0] for p in parameter_strings])
+            try:
+                nr_double_trials = sum(param_names == param_names[0])
+            
+                # we have double trials -- custom procedure!:
+                if nr_double_trials > 1:
+                    nr_params = len(param_names) / nr_double_trials
+                    nr_param = 0
+                    parameter_strings2 = []
+                    for d in range(nr_double_trials):
+                        parameter_strings2.append( parameter_strings[nr_param:nr_param+nr_params] )
+                        nr_param += nr_params
+                    for d in parameter_strings2:
+                        # assuming all these parameters are numeric
+                        this_trial_parameters = {'trial_nr': float(i)}
+                        for s in d:
+                            try:
+                                this_trial_parameters.update({s[0]: float(s[1])})
+                            except ValueError:
+                                pass
+                        parameters.append(this_trial_parameters)
+                
+                # we don't have double trial -- standard procedure!
+                else:
+                    if len(parameter_strings) > 0:
+                        # assuming all these parameters are numeric
+                        this_trial_parameters = {'trial_nr': float(i)}
+                        for s in parameter_strings:
+                            try:
+                                this_trial_parameters.update({s[0]: float(s[1])})
+                            except ValueError:
+                                pass
+                        parameters.append(this_trial_parameters)
+            except:
+                pass
+        
+        if len(parameters) > 0:        # there were parameters in the edf file
+            self.parameters = parameters
+            print([k.keys() for k in self.parameters])
+            ptd = [(k, np.float64) for k in np.unique(np.concatenate([k.keys() for k in self.parameters]))]
+            self.parameter_type_dictionary = np.dtype(ptd)
+        else: # we have to take the parameters from the output_dict pickle file of the same name as the edf file. 
+            self.logger.info('no parameter information in edf file')
+            
+    
+    def read_key_events(self, 
+        key_re = 'MSG\t([\d\.]+)\ttrial X event \<Event\((\d)-Key(\S*?) {\'scancode\': (\d+), \'key\': (\d+)(, \'unicode\': u\'\S*?\',|,) \'mod\': (\d+)}\)\> at (\d+.\d)'):
+        """read_key_events reads experimental events from the message file"""
+        self.logger.info('reading key_events from %s', os.path.split(self.message_file)[-1])
+        self.get_message_string()
+        if not hasattr(self, 'nr_trials'):
+            self.read_trials()
+        
+        events = []
+        this_length = 0
+        for i in range(self.nr_trials):
+            this_key_re = key_re.replace(' X ', ' ' + str(i) + ' ')
+            event_strings = re.findall(re.compile(this_key_re), self.message_string)
+            if len(event_strings) > 0:
+                if len(event_strings[0]) == 8:
+                    events.append([{'EL_timestamp':float(e[0]),'event_type':int(e[1]),'up_down':e[2],'scancode':int(e[3]),'key':int(e[4]),'modifier':int(e[6]), 'exp_timestamp':float(e[7])} for e in event_strings])
+                    this_length = 8
+                elif len(event_strings[0]) == 3:
+                    events.append([{'EL_timestamp':float(e[0]),'event_type':int(e[1]), 'exp_timestamp':float(e[2])} for e in event_strings])
+                    this_length = 3
+        if len(events) > 0:
+            self.events = list(chain.from_iterable(events))
+            #
+            # add types to eventTypeDictionary that specify the relevant trial and time in trial for this event - per run.
+            #
+            if this_length == 8:
+                self.event_type_dictionary = np.dtype([('EL_timestamp', np.float64), ('event_type', np.float64), ('up_down', '|S25'), ('scancode', np.float64), ('key', np.float64), ('modifier', np.float64), ('exp_timestamp', np.float64)])
+            elif this_length == 3:
+                self.event_type_dictionary = np.dtype([('EL_timestamp', np.float64), ('event_type', np.float64), ('exp_timestamp', np.float64)])
+    
+    def read_eyelink_events(self,
+        sacc_re = 'ESACC\t(\S+)[\s\t]+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+.?\d+)',
+        fix_re = 'EFIX\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?\s+(-?\d+\.?\d*)?', 
+        blink_re = 'EBLINK\t(\S+)\s+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d?.?\d*)?'):
+        """
+        read_key_events reads experimental events from the message file. 
+        
+        other sacc_re = 'ESACC\t(\S+)[\s\t]+(-?\d*\.?\d*)\t(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+\.?\d*)\s+(-?\d+.?\d+)', 
 
-		
-		Examples:
-		ESACC	R	2347313	2347487	174	  621.8	  472.4	  662.0	  479.0	   0.99	 
-		EFIX	R	2340362.0	2347312.0	6950	  650.0	  480.4	   5377
-		EBLINK	R	2347352	2347423	71
-		"""
-		self.logger.info('reading eyelink events from %s', os.path.split(self.message_file)[-1])
-		self.get_message_string()
-		saccade_strings = re.findall(re.compile(sacc_re), self.message_string)
-		fix_strings = re.findall(re.compile(fix_re), self.message_string)
-		blink_strings = re.findall(re.compile(blink_re), self.message_string)
-		
-		if len(saccade_strings) > 0:
-			# self.saccades_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3]),'start_x':float(e[4]),'start_y':float(e[5]),'end_x':float(e[6]),'end_y':float(e[7]), 'peak_velocity':float(e[8])} for e in saccade_strings]
-			self.saccades_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3]),'start_x':float(e[4]),'start_y':float(e[5]),'end_x':float(e[6]),'end_y':float(e[7]), 'length':float(e[8]),'peak_velocity':float(e[9])} for e in saccade_strings]
-			self.fixations_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3]),'x':float(e[4]),'y':float(e[5]),'pupil_size':float(e[6])} for e in fix_strings]
-			self.blinks_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3])} for e in blink_strings]
-		
-			self.saccade_type_dictionary = np.dtype([(s , np.array(self.saccades_from_message_file[0][s]).dtype) for s in self.saccades_from_message_file[0].keys()])
-			self.fixation_type_dictionary = np.dtype([(s , np.array(self.fixations_from_message_file[0][s]).dtype) for s in self.fixations_from_message_file[0].keys()])
-			if len(self.blinks_from_message_file) > 0:
-				self.blink_type_dictionary = np.dtype([(s , np.array(self.blinks_from_message_file[0][s]).dtype) for s in self.blinks_from_message_file[0].keys()])
-	
-	def read_sound_events(self, 
-		sound_re = 'MSG\t([\d\.]+)\treward (\d+) at (\d+.\d)'):
-		"""
-		read_sound_events reads sounds from the message file.
-		
-		Example:
-		MSG	1885375.0	sound 0 at 29.3498238511
-		"""
-		self.logger.info('reading sounds from %s', os.path.split(self.message_file)[-1])
-		self.get_message_string()
-		if not hasattr(self, 'nr_trials'):
-			self.read_trials()
-		sounds = []
-		this_length = 0
-		sound_strings = re.findall(re.compile(sound_re), self.message_string)
-		sounds.append([{'EL_timestamp':float(s[0]),'sound_type':int(s[1]), 'exp_timestamp':float(s[2])} for s in sound_strings])
-		self.sounds = list(chain.from_iterable(sounds))
-		#
-		# add types to eventTypeDictionary that specify the relevant trial and time in trial for this event - per run.
-		#
-		self.sound_type_dictionary = np.dtype([('EL_timestamp', np.float64), ('sound_type', np.float64), ('exp_timestamp', np.float64)])
-	
-	def take_gaze_data_for_blocks(self):
-		"""
-		take_gaze_data_for_blocks takes the data per block from self.gaze_file,
-		where a 'block' is a period between startrecording and stoprecording,
-		and puts those data into internal variable self.blocks, identified
-		by the key 'block_data'. Other keys in this dict contain remaining
-		information needed to effectively process these data further (see 
-		self.identify_blocks() 
-		"""
-		# check for gaze data and blocks
-		self.clean_gaze_information()
-		self.identify_blocks()
-		
-		
-		with open(self.gaze_file) as gfd:
-			txt_data = gfd.readlines()
-			float_data = [[float(i) for i in line.split('\t')] for line in txt_data]
-			
-			for i, block in enumerate(self.blocks):
-				block_data = float_data[block['block_start_index']:block['block_end_index']]
-				block['block_data'] = np.array(block_data, dtype = np.float32)
-				self.logger.info('found data from block %i of shape %s'%(i, str(block['block_data'].shape)))
-		
-		
-	
+        
+        Examples:
+        ESACC    R    2347313    2347487    174      621.8      472.4      662.0      479.0       0.99     
+        EFIX    R    2340362.0    2347312.0    6950      650.0      480.4       5377
+        EBLINK    R    2347352    2347423    71
+        """
+        self.logger.info('reading eyelink events from %s', os.path.split(self.message_file)[-1])
+        self.get_message_string()
+        saccade_strings = re.findall(re.compile(sacc_re), self.message_string)
+        fix_strings = re.findall(re.compile(fix_re), self.message_string)
+        blink_strings = re.findall(re.compile(blink_re), self.message_string)
+        
+        if len(saccade_strings) > 0:
+            # self.saccades_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3]),'start_x':float(e[4]),'start_y':float(e[5]),'end_x':float(e[6]),'end_y':float(e[7]), 'peak_velocity':float(e[8])} for e in saccade_strings]
+            self.saccades_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3]),'start_x':float(e[4]),'start_y':float(e[5]),'end_x':float(e[6]),'end_y':float(e[7]), 'length':float(e[8]),'peak_velocity':float(e[9])} for e in saccade_strings]
+            self.fixations_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3]),'x':float(e[4]),'y':float(e[5]),'pupil_size':float(e[6])} for e in fix_strings]
+            self.blinks_from_message_file = [{'eye':e[0],'start_timestamp':float(e[1]),'end_timestamp':float(e[2]),'duration':float(e[3])} for e in blink_strings]
+        
+            self.saccade_type_dictionary = np.dtype([(s , np.array(self.saccades_from_message_file[0][s]).dtype) for s in self.saccades_from_message_file[0].keys()])
+            self.fixation_type_dictionary = np.dtype([(s , np.array(self.fixations_from_message_file[0][s]).dtype) for s in self.fixations_from_message_file[0].keys()])
+            if len(self.blinks_from_message_file) > 0:
+                self.blink_type_dictionary = np.dtype([(s , np.array(self.blinks_from_message_file[0][s]).dtype) for s in self.blinks_from_message_file[0].keys()])
+    
+    def read_sound_events(self, 
+        sound_re = 'MSG\t([\d\.]+)\treward (\d+) at (\d+.\d)'):
+        """
+        read_sound_events reads sounds from the message file.
+        
+        Example:
+        MSG    1885375.0    sound 0 at 29.3498238511
+        """
+        self.logger.info('reading sounds from %s', os.path.split(self.message_file)[-1])
+        self.get_message_string()
+        if not hasattr(self, 'nr_trials'):
+            self.read_trials()
+        sounds = []
+        this_length = 0
+        sound_strings = re.findall(re.compile(sound_re), self.message_string)
+        sounds.append([{'EL_timestamp':float(s[0]),'sound_type':int(s[1]), 'exp_timestamp':float(s[2])} for s in sound_strings])
+        self.sounds = list(chain.from_iterable(sounds))
+        #
+        # add types to eventTypeDictionary that specify the relevant trial and time in trial for this event - per run.
+        #
+        self.sound_type_dictionary = np.dtype([('EL_timestamp', np.float64), ('sound_type', np.float64), ('exp_timestamp', np.float64)])
+    
+    def take_gaze_data_for_blocks(self):
+        """
+        take_gaze_data_for_blocks takes the data per block from self.gaze_file,
+        where a 'block' is a period between startrecording and stoprecording,
+        and puts those data into internal variable self.blocks, identified
+        by the key 'block_data'. Other keys in this dict contain remaining
+        information needed to effectively process these data further (see 
+        self.identify_blocks() 
+        """
+        # check for gaze data and blocks
+        self.clean_gaze_information()
+        self.identify_blocks()
+        
+        
+        with open(self.gaze_file) as gfd:
+            txt_data = gfd.readlines()
+            float_data = [[float(i) for i in line.split('\t')] for line in txt_data]
+            
+            for i, block in enumerate(self.blocks):
+                block_data = float_data[block['block_start_index']:block['block_end_index']]
+                block['block_data'] = np.array(block_data, dtype = np.float32)
+                self.logger.info('found data from block %i of shape %s'%(i, str(block['block_data'].shape)))
+        
+        
+    

--- a/src/EyeSignalOperator.py
+++ b/src/EyeSignalOperator.py
@@ -733,12 +733,12 @@ class EyeSignalOperator(Operator):
         ax5 = plt.subplot(gs[3,:])
         # ax6 = plt.subplot(gs[4,:])
         
-        x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
+        x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0]) / 60.0
         ax1.plot(x, self.raw_pupil, 'b', rasterized=True)
         ax1.plot(x, self.interpolated_pupil, 'g', rasterized=True)
         ax1.set_title('Raw and blink interpolated timeseries')
         ax1.set_ylabel('Pupil size (raw)')
-        ax1.set_xlabel('Time (s)')
+        ax1.set_xlabel('Time (min)')
         ax1.legend(['Raw', 'Int + filt'])
         
         ax2.plot(self.pupil_diff, rasterized=True)
@@ -762,24 +762,13 @@ class EyeSignalOperator(Operator):
         ax4.set_title('Saccade response')
         ax4.set_xlabel('Time (s)')
         ax4.set_ylabel('Pupil size (raw)')
-
-        # try:
-        #     x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
-        #     ax5.plot(x, self.GLM_measured, 'b', rasterized=True)
-        #     ax5.plot(x, self.GLM_predicted, lw=2, color='g', rasterized=True)
-        #     ax5.set_title('Nuisance GLM -- R2={}, p={}'.format(round(self.GLM_r,4), round(self.GLM_p,4)))
-        #     ax5.set_ylabel('Pupil size (raw)')
-        #     ax5.set_xlabel('Time (s)')
-        #     ax5.legend(['measured', 'predicted'])
-        # except:
-        #     pass
         
-        x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
+        x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0]) / 60.0
         ax5.plot(x, self.lp_filt_pupil, 'b', rasterized=True)
         ax5.plot(x, self.lp_filt_pupil_clean, 'g', rasterized=True)
         ax5.set_title('Final timeseries')
-        ax5.set_ylabel('Pupil size (% signal change)')
-        ax5.set_xlabel('Time (s)')
+        ax5.set_ylabel('Pupil size (raw)')
+        ax5.set_xlabel('Time (min)')
         ax5.legend(['low pass', 'low pass + cleaned up'])
         
         plt.tight_layout()

--- a/src/EyeSignalOperator.py
+++ b/src/EyeSignalOperator.py
@@ -31,677 +31,754 @@ import fir
 
 from IPython import embed as shell
 
+def _butter_lowpass(data, highcut, fs, order=5):
+    nyq = 0.5 * fs
+    high = highcut / nyq
+    b, a = sp.signal.butter(order, high, btype='lowpass')
+    y = sp.signal.filtfilt(b, a, data)
+    return y
+
+def _butter_highpass(data, lowcut, fs, order=5):
+    nyq = 0.5 * fs
+    low = lowcut / nyq
+    b, a = sp.signal.butter(order, low, btype='highpass')
+    y = sp.signal.filtfilt(b, a, data)
+    return y
+
+def _butter_bandpass(data, lowcut, highcut, fs, order=5):
+    nyq = 0.5 * fs
+    low = lowcut / nyq
+    high = highcut / nyq
+    data_hp = _butter_highpass(data, lowcut, fs, order)
+    b, a = sp.signal.butter(order, high, btype='lowpass')
+    y = sp.signal.filtfilt(b, a, data_hp)
+    return y
+    
 def detect_saccade_from_data(xy_data = None, vel_data = None, l = 5, sample_rate = 1000.0, minimum_saccade_duration = 0.0075):
-	"""Uses the engbert & mergenthaler algorithm (PNAS 2006) to detect saccades.
-	
-	This function expects a sequence (N x 2) of xy gaze position or velocity data. 
-	
-	Arguments:
-		xy_data (numpy.ndarray, optional): a sequence (N x 2) of xy gaze (float/integer) positions. Defaults to None
-		vel_data (numpy.ndarray, optional): a sequence (N x 2) of velocity data (float/integer). Defaults to None.
-		l (float, optional):determines the threshold. Defaults to 5 median-based standard deviations from the median
-		sample_rate (float, optional) - the rate at which eye movements were measured per second). Defaults to 1000.0
-		minimum_saccade_duration (float, optional) - the minimum duration for something to be considered a saccade). Defaults to 0.0075
-	
-	Returns:
-		list of dictionaries, which each correspond to a saccade.
-		
-		The dictionary contains the following items:
-			
-	Raises:
-		ValueError: If neither xy_data and vel_data were passed to the function.
-	
-	"""
-	
-	# If xy_data and vel_data are both None, function can't continue
-	if xy_data is None and vel_data is None:
-		raise ValueError("Supply either xy_data or vel_data")	
-		
-	#If xy_data is given, process it
-	if not xy_data is None:
-		xy_data = np.array(xy_data)
-		# when are both eyes zeros?
-		xy_data_zeros = (xy_data == 0.0001).sum(axis = 1)
-	
-	# Calculate velocity data if it has not been given to function
-	if vel_data is None:
-		# # Check for shape of xy_data. If x and y are ordered in columns, transpose array.
-		# # Should be 2 x N array to use np.diff namely (not Nx2)
-		# rows, cols = xy_data.shape
-		# if rows == 2:
-		# 	vel_data = np.diff(xy_data)
-		# if cols == 2:
-		# 	vel_data = np.diff(xy_data.T)
-		vel_data = np.zeros(xy_data.shape)
-		vel_data[1:] = np.diff(xy_data, axis = 0)
-	else:
-		vel_data = np.array(vel_data)
+    """Uses the engbert & mergenthaler algorithm (PNAS 2006) to detect saccades.
+    
+    This function expects a sequence (N x 2) of xy gaze position or velocity data. 
+    
+    Arguments:
+        xy_data (numpy.ndarray, optional): a sequence (N x 2) of xy gaze (float/integer) positions. Defaults to None
+        vel_data (numpy.ndarray, optional): a sequence (N x 2) of velocity data (float/integer). Defaults to None.
+        l (float, optional):determines the threshold. Defaults to 5 median-based standard deviations from the median
+        sample_rate (float, optional) - the rate at which eye movements were measured per second). Defaults to 1000.0
+        minimum_saccade_duration (float, optional) - the minimum duration for something to be considered a saccade). Defaults to 0.0075
+    
+    Returns:
+        list of dictionaries, which each correspond to a saccade.
+        
+        The dictionary contains the following items:
+            
+    Raises:
+        ValueError: If neither xy_data and vel_data were passed to the function.
+    
+    """
+    
+    # If xy_data and vel_data are both None, function can't continue
+    if xy_data is None and vel_data is None:
+        raise ValueError("Supply either xy_data or vel_data")    
+        
+    #If xy_data is given, process it
+    if not xy_data is None:
+        xy_data = np.array(xy_data)
+        # when are both eyes zeros?
+        xy_data_zeros = (xy_data == 0.0001).sum(axis = 1)
+    
+    # Calculate velocity data if it has not been given to function
+    if vel_data is None:
+        # # Check for shape of xy_data. If x and y are ordered in columns, transpose array.
+        # # Should be 2 x N array to use np.diff namely (not Nx2)
+        # rows, cols = xy_data.shape
+        # if rows == 2:
+        #     vel_data = np.diff(xy_data)
+        # if cols == 2:
+        #     vel_data = np.diff(xy_data.T)
+        vel_data = np.zeros(xy_data.shape)
+        vel_data[1:] = np.diff(xy_data, axis = 0)
+    else:
+        vel_data = np.array(vel_data)
 
-	# median-based standard deviation, for x and y separately
-	med = np.median(vel_data, axis = 0)
-	
-	scaled_vel_data = vel_data/np.mean(np.array(np.sqrt((vel_data - med)**2)), axis = 0)
-	# normalize and to acceleration and its sign
-	if (float(np.__version__.split('.')[1]) == 1.0) and (float(np.__version__.split('.')[1]) > 6):
-		normed_scaled_vel_data = LA.norm(scaled_vel_data, axis = 1)
-		normed_vel_data = LA.norm(vel_data, axis = 1)
-	else:
-		normed_scaled_vel_data = np.array([LA.norm(svd) for svd in np.array(scaled_vel_data)])
-		normed_vel_data = np.array([LA.norm(vd) for vd in np.array(vel_data)])
-	normed_acc_data = np.r_[0,np.diff(normed_scaled_vel_data)]
-	signed_acc_data = np.sign(normed_acc_data)
-	
-	# when are we above the threshold, and when were the crossings
-	over_threshold = (normed_scaled_vel_data > l)
-	# integers instead of bools preserve the sign of threshold transgression
-	over_threshold_int = np.array(over_threshold, dtype = np.int16)
-	
-	# crossings come in pairs
-	threshold_crossings_int = np.concatenate([[0], np.diff(over_threshold_int)])
-	threshold_crossing_indices = np.arange(threshold_crossings_int.shape[0])[threshold_crossings_int != 0]
-	
-	valid_threshold_crossing_indices = []
-	
-	# if no saccades were found, then we'll just go on and record an empty saccade
-	if threshold_crossing_indices.shape[0] > 1:
-		# the first saccade cannot already have started now
-		if threshold_crossings_int[threshold_crossing_indices[0]] == -1:
-			threshold_crossings_int[threshold_crossing_indices[0]] = 0
-			threshold_crossing_indices = threshold_crossing_indices[1:]
-	
-		# the last saccade cannot be in flight at the end of this data
-		if threshold_crossings_int[threshold_crossing_indices[-1]] == 1:
-			threshold_crossings_int[threshold_crossing_indices[-1]] = 0
-			threshold_crossing_indices = threshold_crossing_indices[:-1]
-		
-		# check the durations of the saccades
-		threshold_crossing_indices_2x2 = threshold_crossing_indices.reshape((-1,2))
-		raw_saccade_durations = np.diff(threshold_crossing_indices_2x2, axis = 1).squeeze()
-	
-		# and check whether these saccades were also blinks...
-		blinks_during_saccades = np.ones(threshold_crossing_indices_2x2.shape[0], dtype = bool)
-		for i in range(blinks_during_saccades.shape[0]):
-			if np.sum(xy_data_zeros[threshold_crossing_indices_2x2[i,0]-20:threshold_crossing_indices_2x2[i,1]+20]) > 0:
-				blinks_during_saccades[i] = False
-	
-		# and are they too close to the end of the interval?
-		right_times = threshold_crossing_indices_2x2[:,1] < xy_data.shape[0]-30
-	
-		valid_saccades_bool = ((raw_saccade_durations / float(sample_rate) > minimum_saccade_duration) * blinks_during_saccades ) * right_times
-		if type(valid_saccades_bool) != np.ndarray:
-			valid_threshold_crossing_indices = threshold_crossing_indices_2x2
-		else:
-			valid_threshold_crossing_indices = threshold_crossing_indices_2x2[valid_saccades_bool]
-		
-	saccades = []
-	for i, cis in enumerate(valid_threshold_crossing_indices):
-		# find the real start and end of the saccade by looking at when the acceleleration reverses sign before the start and after the end of the saccade:
-		# sometimes the saccade has already started?
-		expanded_saccade_start = np.arange(cis[0])[np.r_[0,np.diff(signed_acc_data[:cis[0]] != 1)] != 0]
-		if expanded_saccade_start.shape[0] > 0:
-			expanded_saccade_start = expanded_saccade_start[-1]
-		else:
-			expanded_saccade_start = 0
-			
-		expanded_saccade_end = np.arange(cis[1],np.min([cis[1]+50, xy_data.shape[0]]))[np.r_[0,np.diff(signed_acc_data[cis[1]:np.min([cis[1]+50, xy_data.shape[0]])] != -1)] != 0]
-		# sometimes the deceleration continues crazily, we'll just have to cut it off then. 
-		if expanded_saccade_end.shape[0] > 0:
-			expanded_saccade_end = expanded_saccade_end[0]
-		else:
-			expanded_saccade_end = np.min([cis[1]+50, xy_data.shape[0]])
-		
-		try:
-			this_saccade = {
-				'expanded_start_time': expanded_saccade_start,
-				'expanded_end_time': expanded_saccade_end,
-				'expanded_duration': expanded_saccade_end - expanded_saccade_start,
-				'expanded_start_point': xy_data[expanded_saccade_start],
-				'expanded_end_point': xy_data[expanded_saccade_end],
-				'expanded_vector': xy_data[expanded_saccade_end] - xy_data[expanded_saccade_start],
-				'expanded_amplitude': np.sum(normed_vel_data[expanded_saccade_start:expanded_saccade_end]) / sample_rate,
-				'peak_velocity': np.max(normed_vel_data[expanded_saccade_start:expanded_saccade_end]),
+    # median-based standard deviation, for x and y separately
+    med = np.median(vel_data, axis = 0)
+    
+    scaled_vel_data = vel_data/np.mean(np.array(np.sqrt((vel_data - med)**2)), axis = 0)
+    # normalize and to acceleration and its sign
+    if (float(np.__version__.split('.')[1]) == 1.0) and (float(np.__version__.split('.')[1]) > 6):
+        normed_scaled_vel_data = LA.norm(scaled_vel_data, axis = 1)
+        normed_vel_data = LA.norm(vel_data, axis = 1)
+    else:
+        normed_scaled_vel_data = np.array([LA.norm(svd) for svd in np.array(scaled_vel_data)])
+        normed_vel_data = np.array([LA.norm(vd) for vd in np.array(vel_data)])
+    normed_acc_data = np.r_[0,np.diff(normed_scaled_vel_data)]
+    signed_acc_data = np.sign(normed_acc_data)
+    
+    # when are we above the threshold, and when were the crossings
+    over_threshold = (normed_scaled_vel_data > l)
+    # integers instead of bools preserve the sign of threshold transgression
+    over_threshold_int = np.array(over_threshold, dtype = np.int16)
+    
+    # crossings come in pairs
+    threshold_crossings_int = np.concatenate([[0], np.diff(over_threshold_int)])
+    threshold_crossing_indices = np.arange(threshold_crossings_int.shape[0])[threshold_crossings_int != 0]
+    
+    valid_threshold_crossing_indices = []
+    
+    # if no saccades were found, then we'll just go on and record an empty saccade
+    if threshold_crossing_indices.shape[0] > 1:
+        # the first saccade cannot already have started now
+        if threshold_crossings_int[threshold_crossing_indices[0]] == -1:
+            threshold_crossings_int[threshold_crossing_indices[0]] = 0
+            threshold_crossing_indices = threshold_crossing_indices[1:]
+    
+        # the last saccade cannot be in flight at the end of this data
+        if threshold_crossings_int[threshold_crossing_indices[-1]] == 1:
+            threshold_crossings_int[threshold_crossing_indices[-1]] = 0
+            threshold_crossing_indices = threshold_crossing_indices[:-1]
+        
+#        if threshold_crossing_indices.shape == 0:
+#            break
+        # check the durations of the saccades
+        threshold_crossing_indices_2x2 = threshold_crossing_indices.reshape((-1,2))
+        raw_saccade_durations = np.diff(threshold_crossing_indices_2x2, axis = 1).squeeze()
+    
+        # and check whether these saccades were also blinks...
+        blinks_during_saccades = np.ones(threshold_crossing_indices_2x2.shape[0], dtype = bool)
+        for i in range(blinks_during_saccades.shape[0]):
+            if np.sum(xy_data_zeros[threshold_crossing_indices_2x2[i,0]-20:threshold_crossing_indices_2x2[i,1]+20]) > 0:
+                blinks_during_saccades[i] = False
+    
+        # and are they too close to the end of the interval?
+        right_times = threshold_crossing_indices_2x2[:,1] < xy_data.shape[0]-30
+    
+        valid_saccades_bool = ((raw_saccade_durations / float(sample_rate) > minimum_saccade_duration) * blinks_during_saccades ) * right_times
+        if type(valid_saccades_bool) != np.ndarray:
+            valid_threshold_crossing_indices = threshold_crossing_indices_2x2
+        else:
+            valid_threshold_crossing_indices = threshold_crossing_indices_2x2[valid_saccades_bool]
+    
+        # print threshold_crossing_indices_2x2, valid_threshold_crossing_indices, blinks_during_saccades, ((raw_saccade_durations / sample_rate) > minimum_saccade_duration), right_times, valid_saccades_bool
+        # print raw_saccade_durations, sample_rate, minimum_saccade_duration        
+    
+    saccades = []
+    for i, cis in enumerate(valid_threshold_crossing_indices):
+        # find the real start and end of the saccade by looking at when the acceleleration reverses sign before the start and after the end of the saccade:
+        # sometimes the saccade has already started?
+        expanded_saccade_start = np.arange(cis[0])[np.r_[0,np.diff(signed_acc_data[:cis[0]] != 1)] != 0]
+        if expanded_saccade_start.shape[0] > 0:
+            expanded_saccade_start = expanded_saccade_start[-1]
+        else:
+            expanded_saccade_start = 0
+            
+        expanded_saccade_end = np.arange(cis[1],np.min([cis[1]+50, xy_data.shape[0]]))[np.r_[0,np.diff(signed_acc_data[cis[1]:np.min([cis[1]+50, xy_data.shape[0]])] != -1)] != 0]
+        # sometimes the deceleration continues crazily, we'll just have to cut it off then. 
+        if expanded_saccade_end.shape[0] > 0:
+            expanded_saccade_end = expanded_saccade_end[0]
+        else:
+            expanded_saccade_end = np.min([cis[1]+50, xy_data.shape[0]])
+        
+        try:
+            this_saccade = {
+                'expanded_start_time': expanded_saccade_start,
+                'expanded_end_time': expanded_saccade_end,
+                'expanded_duration': expanded_saccade_end - expanded_saccade_start,
+                'expanded_start_point': xy_data[expanded_saccade_start],
+                'expanded_end_point': xy_data[expanded_saccade_end],
+                'expanded_vector': xy_data[expanded_saccade_end] - xy_data[expanded_saccade_start],
+                'expanded_amplitude': np.sum(normed_vel_data[expanded_saccade_start:expanded_saccade_end]) / sample_rate,
+                'peak_velocity': np.max(normed_vel_data[expanded_saccade_start:expanded_saccade_end]),
 
-				'raw_start_time': cis[0],
-				'raw_end_time': cis[1],
-				'raw_duration': cis[1] - cis[0],
-				'raw_start_point': xy_data[cis[1]],
-				'raw_end_point': xy_data[cis[0]],
-				'raw_vector': xy_data[cis[1]] - xy_data[cis[0]],
-				'raw_amplitude': np.sum(normed_vel_data[cis[0]:cis[1]]) / sample_rate,
-			}
-			saccades.append(this_saccade)
-		except IndexError:
-			pass
-		
-	
-	# if this fucker was empty
-	if len(valid_threshold_crossing_indices) == 0:
-		this_saccade = {
-			'expanded_start_time': 0,
-			'expanded_end_time': 0,
-			'expanded_duration': 0.0,
-			'expanded_start_point': [0.0,0.0],
-			'expanded_end_point': [0.0,0.0],
-			'expanded_vector': [0.0,0.0],
-			'expanded_amplitude': 0.0,
-			'peak_velocity': 0.0,
+                'raw_start_time': cis[0],
+                'raw_end_time': cis[1],
+                'raw_duration': cis[1] - cis[0],
+                'raw_start_point': xy_data[cis[1]],
+                'raw_end_point': xy_data[cis[0]],
+                'raw_vector': xy_data[cis[1]] - xy_data[cis[0]],
+                'raw_amplitude': np.sum(normed_vel_data[cis[0]:cis[1]]) / sample_rate,
+            }
+            saccades.append(this_saccade)
+        except IndexError:
+            pass
+        
+    
+    # if this fucker was empty
+    if len(valid_threshold_crossing_indices) == 0:
+        this_saccade = {
+            'expanded_start_time': 0,
+            'expanded_end_time': 0,
+            'expanded_duration': 0.0,
+            'expanded_start_point': [0.0,0.0],
+            'expanded_end_point': [0.0,0.0],
+            'expanded_vector': [0.0,0.0],
+            'expanded_amplitude': 0.0,
+            'peak_velocity': 0.0,
 
-			'raw_start_time': 0,
-			'raw_end_time': 0,
-			'raw_duration': 0.0,
-			'raw_start_point': [0.0,0.0],
-			'raw_end_point': [0.0,0.0],
-			'raw_vector': [0.0,0.0],
-			'raw_amplitude': 0.0,
-		}
-		saccades.append(this_saccade)
+            'raw_start_time': 0,
+            'raw_end_time': 0,
+            'raw_duration': 0.0,
+            'raw_start_point': [0.0,0.0],
+            'raw_end_point': [0.0,0.0],
+            'raw_vector': [0.0,0.0],
+            'raw_amplitude': 0.0,
+        }
+        saccades.append(this_saccade)
 
-	return saccades
+    # shell()
+    return saccades
 
 def detect_peaks(x, mph=None, mpd=1, threshold=0, edge='rising', kpsh=False, valley=False, show=False, ax=None):
 
-	"""Detect peaks in data based on their amplitude and other features.
-	Parameters
-	----------
-	x : 1D array_like
-		data.
-	mph : {None, number}, optional (default = None)
-		detect peaks that are greater than minimum peak height.
-	mpd : positive integer, optional (default = 1)
-		detect peaks that are at least separated by minimum peak distance (in
-		number of data).
-	threshold : positive number, optional (default = 0)
-		detect peaks (valleys) that are greater (smaller) than `threshold`
-		in relation to their immediate neighbors.
-	edge : {None, 'rising', 'falling', 'both'}, optional (default = 'rising')
-		for a flat peak, keep only the rising edge ('rising'), only the
-		falling edge ('falling'), both edges ('both'), or don't detect a
-		flat peak (None).
-	kpsh : bool, optional (default = False)
-		keep peaks with same height even if they are closer than `mpd`.
-	valley : bool, optional (default = False)
-		if True (1), detect valleys (local minima) instead of peaks.
-	show : bool, optional (default = False)
-		if True (1), plot data in matplotlib figure.
-	ax : a matplotlib.axes.Axes instance, optional (default = None).
-	Returns
-	-------
-	ind : 1D array_like
-		indeces of the peaks in `x`.
-	Notes
-	-----
-	The detection of valleys instead of peaks is performed internally by simply
-	negating the data: `ind_valleys = detect_peaks(-x)`
+    """Detect peaks in data based on their amplitude and other features.
+    Parameters
+    ----------
+    x : 1D array_like
+        data.
+    mph : {None, number}, optional (default = None)
+        detect peaks that are greater than minimum peak height.
+    mpd : positive integer, optional (default = 1)
+        detect peaks that are at least separated by minimum peak distance (in
+        number of data).
+    threshold : positive number, optional (default = 0)
+        detect peaks (valleys) that are greater (smaller) than `threshold`
+        in relation to their immediate neighbors.
+    edge : {None, 'rising', 'falling', 'both'}, optional (default = 'rising')
+        for a flat peak, keep only the rising edge ('rising'), only the
+        falling edge ('falling'), both edges ('both'), or don't detect a
+        flat peak (None).
+    kpsh : bool, optional (default = False)
+        keep peaks with same height even if they are closer than `mpd`.
+    valley : bool, optional (default = False)
+        if True (1), detect valleys (local minima) instead of peaks.
+    show : bool, optional (default = False)
+        if True (1), plot data in matplotlib figure.
+    ax : a matplotlib.axes.Axes instance, optional (default = None).
+    Returns
+    -------
+    ind : 1D array_like
+        indeces of the peaks in `x`.
+    Notes
+    -----
+    The detection of valleys instead of peaks is performed internally by simply
+    negating the data: `ind_valleys = detect_peaks(-x)`
+    The function can handle NaN's 
+    See this IPython Notebook [1]_.
+    References
+    ----------
+    .. [1] http://nbviewer.ipython.org/github/demotu/BMC/blob/master/notebooks/DetectPeaks.ipynb
+    Examples
+    --------
+    >>> from detect_peaks import detect_peaks
+    >>> x = np.random.randn(100)
+    >>> x[60:81] = np.nan
+    >>> # detect all peaks and plot data
+    >>> ind = detect_peaks(x, show=True)
+    >>> print(ind)
+    >>> x = np.sin(2*np.pi*5*np.linspace(0, 1, 200)) + np.random.randn(200)/5
+    >>> # set minimum peak height = 0 and minimum peak distance = 20
+    >>> detect_peaks(x, mph=0, mpd=20, show=True)
+    >>> x = [0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0]
+    >>> # set minimum peak distance = 2
+    >>> detect_peaks(x, mpd=2, show=True)
+    >>> x = np.sin(2*np.pi*5*np.linspace(0, 1, 200)) + np.random.randn(200)/5
+    >>> # detection of valleys instead of peaks
+    >>> detect_peaks(x, mph=0, mpd=20, valley=True, show=True)
+    >>> x = [0, 1, 1, 0, 1, 1, 0]
+    >>> # detect both edges
+    >>> detect_peaks(x, edge='both', show=True)
+    >>> x = [-2, 1, -2, 2, 1, 1, 3, 0]
+    >>> # set threshold = 2
+    >>> detect_peaks(x, threshold = 2, show=True)
+    """
 
-	The function can handle NaN's 
-	See this IPython Notebook [1]_.
-	References
-	----------
-	.. [1] http://nbviewer.ipython.org/github/demotu/BMC/blob/master/notebooks/DetectPeaks.ipynb
-	Examples
-	--------
-	>>> from detect_peaks import detect_peaks
-	>>> x = np.random.randn(100)
-	>>> x[60:81] = np.nan
-	>>> # detect all peaks and plot data
-	>>> ind = detect_peaks(x, show=True)
-	>>> print(ind)
-	>>> x = np.sin(2*np.pi*5*np.linspace(0, 1, 200)) + np.random.randn(200)/5
-	>>> # set minimum peak height = 0 and minimum peak distance = 20
-	>>> detect_peaks(x, mph=0, mpd=20, show=True)
-	>>> x = [0, 1, 0, 2, 0, 3, 0, 2, 0, 1, 0]
-	>>> # set minimum peak distance = 2
-	>>> detect_peaks(x, mpd=2, show=True)
-	>>> x = np.sin(2*np.pi*5*np.linspace(0, 1, 200)) + np.random.randn(200)/5
-	>>> # detection of valleys instead of peaks
-	>>> detect_peaks(x, mph=0, mpd=20, valley=True, show=True)
-	>>> x = [0, 1, 1, 0, 1, 1, 0]
-	>>> # detect both edges
-	>>> detect_peaks(x, edge='both', show=True)
-	>>> x = [-2, 1, -2, 2, 1, 1, 3, 0]
-	>>> # set threshold = 2
-	>>> detect_peaks(x, threshold = 2, show=True)
-	"""
+    x = np.atleast_1d(x).astype('float64')
+    if x.size < 3:
+        return np.array([], dtype=int)
+    if valley:
+        x = -x
+    # find indices of all peaks
+    dx = x[1:] - x[:-1]
+    # handle NaN's
+    indnan = np.where(np.isnan(x))[0]
+    if indnan.size:
+        x[indnan] = np.inf
+        dx[np.where(np.isnan(dx))[0]] = np.inf
+    ine, ire, ife = np.array([[], [], []], dtype=int)
+    if not edge:
+        ine = np.where((np.hstack((dx, 0)) < 0) & (np.hstack((0, dx)) > 0))[0]
+    else:
+        if edge.lower() in ['rising', 'both']:
+            ire = np.where((np.hstack((dx, 0)) <= 0) & (np.hstack((0, dx)) > 0))[0]
+        if edge.lower() in ['falling', 'both']:
+            ife = np.where((np.hstack((dx, 0)) < 0) & (np.hstack((0, dx)) >= 0))[0]
+    ind = np.unique(np.hstack((ine, ire, ife)))
+    # handle NaN's
+    if ind.size and indnan.size:
+        # NaN's and values close to NaN's cannot be peaks
+        ind = ind[np.in1d(ind, np.unique(np.hstack((indnan, indnan-1, indnan+1))), invert=True)]
+    # first and last values of x cannot be peaks
+    if ind.size and ind[0] == 0:
+        ind = ind[1:]
+    if ind.size and ind[-1] == x.size-1:
+        ind = ind[:-1]
+    # remove peaks < minimum peak height
+    if ind.size and mph is not None:
+        ind = ind[x[ind] >= mph]
+    # remove peaks - neighbors < threshold
+    if ind.size and threshold > 0:
+        dx = np.min(np.vstack([x[ind]-x[ind-1], x[ind]-x[ind+1]]), axis=0)
+        ind = np.delete(ind, np.where(dx < threshold)[0])
+    # detect small peaks closer than minimum peak distance
+    if ind.size and mpd > 1:
+        ind = ind[np.argsort(x[ind])][::-1]  # sort ind by peak height
+        idel = np.zeros(ind.size, dtype=bool)
+        for i in range(ind.size):
+            if not idel[i]:
+                # keep peaks with the same height if kpsh is True
+                idel = idel | (ind >= ind[i] - mpd) & (ind <= ind[i] + mpd) \
+                    & (x[ind[i]] > x[ind] if kpsh else True)
+                idel[i] = 0  # Keep current peak
+        # remove the small peaks and sort back the indices by their occurrence
+        ind = np.sort(ind[~idel])
 
-	x = np.atleast_1d(x).astype('float64')
-	if x.size < 3:
-		return np.array([], dtype=int)
-	if valley:
-		x = -x
-	# find indices of all peaks
-	dx = x[1:] - x[:-1]
-	# handle NaN's
-	indnan = np.where(np.isnan(x))[0]
-	if indnan.size:
-		x[indnan] = np.inf
-		dx[np.where(np.isnan(dx))[0]] = np.inf
-	ine, ire, ife = np.array([[], [], []], dtype=int)
-	if not edge:
-		ine = np.where((np.hstack((dx, 0)) < 0) & (np.hstack((0, dx)) > 0))[0]
-	else:
-		if edge.lower() in ['rising', 'both']:
-			ire = np.where((np.hstack((dx, 0)) <= 0) & (np.hstack((0, dx)) > 0))[0]
-		if edge.lower() in ['falling', 'both']:
-			ife = np.where((np.hstack((dx, 0)) < 0) & (np.hstack((0, dx)) >= 0))[0]
-	ind = np.unique(np.hstack((ine, ire, ife)))
-	# handle NaN's
-	if ind.size and indnan.size:
-		# NaN's and values close to NaN's cannot be peaks
-		ind = ind[np.in1d(ind, np.unique(np.hstack((indnan, indnan-1, indnan+1))), invert=True)]
-	# first and last values of x cannot be peaks
-	if ind.size and ind[0] == 0:
-		ind = ind[1:]
-	if ind.size and ind[-1] == x.size-1:
-		ind = ind[:-1]
-	# remove peaks < minimum peak height
-	if ind.size and mph is not None:
-		ind = ind[x[ind] >= mph]
-	# remove peaks - neighbors < threshold
-	if ind.size and threshold > 0:
-		dx = np.min(np.vstack([x[ind]-x[ind-1], x[ind]-x[ind+1]]), axis=0)
-		ind = np.delete(ind, np.where(dx < threshold)[0])
-	# detect small peaks closer than minimum peak distance
-	if ind.size and mpd > 1:
-		ind = ind[np.argsort(x[ind])][::-1]  # sort ind by peak height
-		idel = np.zeros(ind.size, dtype=bool)
-		for i in range(ind.size):
-			if not idel[i]:
-				# keep peaks with the same height if kpsh is True
-				idel = idel | (ind >= ind[i] - mpd) & (ind <= ind[i] + mpd) \
-					& (x[ind[i]] > x[ind] if kpsh else True)
-				idel[i] = 0  # Keep current peak
-		# remove the small peaks and sort back the indices by their occurrence
-		ind = np.sort(ind[~idel])
+    if show:
+        if indnan.size:
+            x[indnan] = np.nan
+        if valley:
+            x = -x
+        _plot(x, mph, mpd, threshold, edge, valley, ax, ind)
 
-	if show:
-		if indnan.size:
-			x[indnan] = np.nan
-		if valley:
-			x = -x
-		_plot(x, mph, mpd, threshold, edge, valley, ax, ind)
-
-	return ind
-
-
-def _plot(x, mph, mpd, threshold, edge, valley, ax, ind):
-	"""Plot results of the detect_peaks function, see its help."""
-	if ax is None:
-		_, ax = pl.subplots(1, 1, figsize=(8, 4))
-
-	ax.plot(x, 'b', lw=1)
-	if ind.size:
-		label = 'valley' if valley else 'peak'
-		label = label + 's' if ind.size > 1 else label
-		ax.plot(ind, x[ind], '+', mfc=None, mec='r', mew=2, ms=8,
-				label='%d %s' % (ind.size, label))
-		ax.legend(loc='best', framealpha=.5, numpoints=1)
-	ax.set_xlim(-.02*x.size, x.size*1.02-1)
-	ymin, ymax = x[np.isfinite(x)].min(), x[np.isfinite(x)].max()
-	yrange = ymax - ymin if ymax > ymin else 1
-	ax.set_ylim(ymin - 0.1*yrange, ymax + 0.1*yrange)
-	ax.set_xlabel('Data #', fontsize=14)
-	ax.set_ylabel('Amplitude', fontsize=14)
-	mode = 'Valley detection' if valley else 'Peak detection'
-	ax.set_title("%s (mph=%s, mpd=%d, threshold=%s, edge='%s')"
-				 % (mode, str(mph), mpd, str(threshold), edge))
+    return ind
 
 class EyeSignalOperator(Operator):
-	"""
-	EyeSignalOperator operates on eye signals, preferably sampled at 1000 Hz. 
-	This operator is just created by feeding it timepoints,
-	eye signals and pupil size signals in separate arrays, on a per-eye basis.
-	
-	Upon init it creates internal variables self.timepoints, self.raw_gazeXY, self.raw_pupil, self.sample_rate
-	and, if available, self.blink_dur, self.blink_starts and self.blink_ends
-	
-	Its further methods create internal variables storing more derived
-	signals that result from further processing.
-	"""
-	def __init__(self, input_object, **kwargs):
-		"""input_object is a dictionary with timepoints, gaze_X, and gaze_Y and pupil keys and timeseries as values"""
-		super(EyeSignalOperator, self).__init__(input_object = input_object, **kwargs)
-		self.timepoints = np.array(self.input_object['timepoints']).squeeze()
-		self.raw_gaze_X = np.array(self.input_object['gaze_X']).squeeze()
-		self.raw_gaze_Y = np.array(self.input_object['gaze_Y']).squeeze()
-		self.raw_pupil = np.array(self.input_object['pupil']).squeeze()
-		
-		if hasattr(self, 'eyelink_blink_data'):
-			# internalize all blinks smaller than 4 seconds, since these are missing signals to be treated differently
-			self.blink_dur_EL = np.array(self.eyelink_blink_data['duration']) 
-			self.blink_starts_EL = np.array(self.eyelink_blink_data['start_timestamp'])[self.blink_dur_EL<4000] - self.timepoints[0]
-			self.blink_ends_EL = np.array(self.eyelink_blink_data['end_timestamp'])[self.blink_dur_EL<4000] - self.timepoints[0]
-			self.blink_dur_EL = np.array(self.eyelink_blink_data['duration'])[self.blink_dur_EL<4000]		
-		
-		if hasattr(self, 'eyelink_sac_data'):
-			self.sac_dur_EL = np.array(self.eyelink_sac_data['duration']) 
-			self.sac_starts_EL = np.array(self.eyelink_sac_data['start_timestamp']) - self.timepoints[0]
-			self.sac_ends_EL = np.array(self.eyelink_sac_data['end_timestamp']) - self.timepoints[0]
-		
-		if not hasattr(self, 'sample_rate'): # this should have been set as a kwarg, but if it hasn't we just assume a standard 1000 Hz
-			self.sample_rate = 1000.0
+    """
+    EyeSignalOperator operates on eye signals, preferably sampled at 1000 Hz. 
+    This operator is just created by feeding it timepoints,
+    eye signals and pupil size signals in separate arrays, on a per-eye basis.
+    
+    Upon init it creates internal variables self.timepoints, self.raw_gazeXY, self.raw_pupil, self.sample_rate
+    and, if available, self.blink_dur, self.blink_starts and self.blink_ends
+    
+    Its further methods create internal variables storing more derived
+    signals that result from further processing.
+    """
+    def __init__(self, input_object, **kwargs):
+        """input_object is a dictionary with timepoints, gaze_X, and gaze_Y and pupil keys and timeseries as values"""
+        super(EyeSignalOperator, self).__init__(input_object = input_object, **kwargs)
+        self.timepoints = np.array(self.input_object['timepoints']).squeeze()
+        self.raw_gaze_X = np.array(self.input_object['gaze_X']).squeeze()
+        self.raw_gaze_Y = np.array(self.input_object['gaze_Y']).squeeze()
+        self.raw_pupil = np.array(self.input_object['pupil']).squeeze()
+        
+        if hasattr(self, 'eyelink_blink_data'):
+            # internalize all blinks smaller than 4 seconds, since these are missing signals to be treated differently
+            self.blink_dur_EL = np.array(self.eyelink_blink_data['duration']) 
+            self.blink_starts_EL = np.array(self.eyelink_blink_data['start_timestamp'])[self.blink_dur_EL<4000] - self.timepoints[0]
+            self.blink_ends_EL = np.array(self.eyelink_blink_data['end_timestamp'])[self.blink_dur_EL<4000] - self.timepoints[0]
+            self.blink_dur_EL = np.array(self.eyelink_blink_data['duration'])[self.blink_dur_EL<4000]        
+        
+        if hasattr(self, 'eyelink_sac_data'):
+            self.sac_dur_EL = np.array(self.eyelink_sac_data['duration']) 
+            self.sac_starts_EL = np.array(self.eyelink_sac_data['start_timestamp']) - self.timepoints[0]
+            self.sac_ends_EL = np.array(self.eyelink_sac_data['end_timestamp']) - self.timepoints[0]
+        
+        if not hasattr(self, 'sample_rate'): # this should have been set as a kwarg, but if it hasn't we just assume a standard 1000 Hz
+            self.sample_rate = 1000.0
 
-	
-	def interpolate_blinks(self, method='linear', lin_interpolation_points=[[-200],[200]], spline_interpolation_points=[[-0.15,-0.075], [0.075,0.15]], coalesce_period=500, threshold_level = 0.01):
-		"""
-		interpolate_blinks interpolates blink periods with method, which can be spline or linear.
-		spline_interpolation_points is a 2 by X list detailing the data points around the blinks
-		(in s offset from blink start and end) that should be used for fitting the interpolation spline.
+    def interpolate_blinks(self, method='linear', lin_interpolation_points=[[-150],[150]], spline_interpolation_points=[[-0.15,-0.075], [0.075,0.15]], coalesce_period=500):
+        """
+        interpolate_blinks interpolates blink periods with method, which can be spline or linear.
+        Use after self.blink_detection_pupil().
+        spline_interpolation_points is a 2 by X list detailing the data points around the blinks
+        (in s offset from blink start and end) that should be used for fitting the interpolation spline.
 
-		The coalesce_period and threshold_level arguments serve to coalesce closely spaced blinks, 
-		but only when eyelink-detected blinks are not provided. 
-		The interval within which blinks have to fall in order to be grouped together is defined 
-		by the coalesce_period, threshold_level determines the level at which data is regarded as 'missing data'.  
+        The results are stored in self.interpolated_pupil, self.interpolated_x and self.interpolated_y
+        without affecting the self.raw_... variables
 
-		The results are stored in self.interpolated_pupil, self.interpolated_x and self.interpolated_y
-		without affecting the self.raw_... variables
+        After calling this method, additional interpolation may be performed by calling self.interpolate_blinks2()
+        """
+        self.logger.info('Interpolating blinks using interpolate_blinks')
+        # set all missing data to 0:
+        self.raw_pupil[self.raw_pupil<1] = 0
+        
+        # blinks to work with -- preferably eyelink!
+        if hasattr(self, 'eyelink_blink_data'):
+            for i in range(len(self.blink_starts_EL)):
+                self.raw_pupil[int(self.blink_starts_EL[i]):int(self.blink_ends_EL[i])] = 0 # set all eyelink-identified blinks to 0:
+        # else:
+        #     self.blinks_indices = pd.rolling_mean(np.array(self.raw_pupil < threshold_level, dtype = float), int(coalesce_period)) > 0
+        #     self.blinks_indices = np.array(self.blinks_indices, dtype=int)
+        #     self.blink_starts = self.timepoints[:-1][np.diff(self.blinks_indices) == 1]
+        #     self.blink_ends = self.timepoints[:-1][np.diff(self.blinks_indices) == -1]
+        #     # now make sure we're only looking at the blnks that fall fully inside the data stream
+        #     try:
+        #         if self.blink_starts[0] > self.blink_ends[0]:
+        #             self.blink_ends = self.blink_ends[1:]
+        #         if self.blink_starts[-1] > self.blink_ends[-1]:
+        #             self.blink_starts = self.blink_starts[:-1]
+        #     except:
+        #         shell()
+        
+        # we do not want to start or end with a 0:
+        import copy
+        self.interpolated_pupil = copy.copy(self.raw_pupil[:])
+        self.interpolated_x = copy.copy(self.raw_gaze_X)
+        self.interpolated_y = copy.copy(self.raw_gaze_Y)
+        self.interpolated_pupil[:coalesce_period] = np.mean(self.interpolated_pupil[np.where(self.interpolated_pupil > 0)[0][:1000]])
+        self.interpolated_pupil[-coalesce_period:] = np.mean(self.interpolated_pupil[np.where(self.interpolated_pupil > 0)[0][-1000:]])
+        self.interpolated_x[:coalesce_period] = np.mean(self.interpolated_x[np.where(self.interpolated_pupil > 0)[0][:1000]])
+        self.interpolated_x[-coalesce_period:] = np.mean(self.interpolated_x[np.where(self.interpolated_pupil > 0)[0][-1000:]])
+        self.interpolated_y[:coalesce_period] = np.mean(self.interpolated_y[np.where(self.interpolated_pupil > 0)[0][:1000]])
+        self.interpolated_y[-coalesce_period:] = np.mean(self.interpolated_y[np.where(self.interpolated_pupil > 0)[0][-1000:]])
+        
+        # detect zero edges (we just created from blinks, plus missing data):
+        zero_edges = np.arange(self.interpolated_pupil.shape[0])[np.diff((self.interpolated_pupil<1))]
+        if zero_edges.shape[0] == 0:
+            pass
+        else:
+            zero_edges = zero_edges[:int(2 * np.floor(zero_edges.shape[0]/2.0))].reshape(-1,2)
+        
+        try:
+            self.blink_starts = zero_edges[:,0]
+            self.blink_ends = zero_edges[:,1]
+        except: # in case there are no blinks!
+            self.blink_starts = np.array([coalesce_period/2.0])
+            self.blink_ends = np.array([(coalesce_period/2.0)+10])
+        
+        # check for neighbouring blinks (coalesce_period, default is 500ms), and string them together:
+        start_indices = np.ones(self.blink_starts.shape[0], dtype=bool)
+        end_indices = np.ones(self.blink_ends.shape[0], dtype=bool)
+        for i in range(self.blink_starts.shape[0]):
+            try:
+                if self.blink_starts[i+1] - self.blink_ends[i] <= coalesce_period:
+                    start_indices[i+1] = False
+                    end_indices[i] = False
+            except IndexError:
+                pass
+        
+        # these are the blink start and end samples to work with:
+        if sum(start_indices) > 0:
+            self.blink_starts = self.blink_starts[start_indices]
+            self.blink_ends = self.blink_ends[end_indices]
+        else:
+            self.blink_starts = None
+            self.blink_ends = None
+            
+        # do actual interpolation:
+        if method == 'spline':
+            points_for_interpolation = np.array(np.array(spline_interpolation_points) * self.sample_rate, dtype = int)
+            for bs, be in zip(self.blink_starts, self.blink_ends):
+                samples = np.ravel(np.array([bs + points_for_interpolation[0], be + points_for_interpolation[1]]))
+                sample_indices = np.arange(self.raw_pupil.shape[0])[np.sum(np.array([self.timepoints == s for s in samples]), axis = 0)]
+                spline = interpolate.InterpolatedUnivariateSpline(sample_indices,self.raw_pupil[sample_indices])
+                self.interpolated_pupil[sample_indices[0]:sample_indices[-1]] = spline(np.arange(sample_indices[1],sample_indices[-2]))
+                spline = interpolate.InterpolatedUnivariateSpline(sample_indices,self.raw_gaze_X[sample_indices])
+                self.interpolated_x[sample_indices[0]:sample_indices[-1]] = spline(np.arange(sample_indices[1],sample_indices[-2]))
+                spline = interpolate.InterpolatedUnivariateSpline(sample_indices,self.raw_gaze_Y[sample_indices])
+                self.interpolated_y[sample_indices[0]:sample_indices[-1]] = spline(np.arange(sample_indices[1],sample_indices[-2]))
+        elif method == 'linear':
+            if self.blink_starts != None:
+                points_for_interpolation = np.array([self.blink_starts, self.blink_ends], dtype=int).T + np.array(lin_interpolation_points).T
+                for itp in points_for_interpolation:
+                    self.interpolated_pupil[itp[0]:itp[-1]] = np.linspace(self.interpolated_pupil[itp[0]], self.interpolated_pupil[itp[-1]], itp[-1]-itp[0])
+                    self.interpolated_x[itp[0]:itp[-1]] = np.linspace(self.interpolated_x[itp[0]], self.interpolated_x[itp[-1]], itp[-1]-itp[0])
+                    self.interpolated_y[itp[0]:itp[-1]] = np.linspace(self.interpolated_y[itp[0]], self.interpolated_y[itp[-1]], itp[-1]-itp[0])
+    
+    def interpolate_blinks2(self, lin_interpolation_points = [[-150],[150]], coalesce_period=500):
+        
+        """
+        interpolate_blinks2 performs linear interpolation around peaks in the rate of change of
+        the pupil size.
+        
+        The results are stored in self.interpolated_pupil, self.interpolated_x and self.interpolated_y
+        without affecting the self.raw_... variables.
+        
+        This method is typically called after an initial interpolation using self.interpolateblinks(),
+        consistent with the fact that this method expects the self.interpolated_... variables to already exist.
+        """
+        
+        # self.pupil_diff = (np.diff(self.interpolated_pupil) - np.diff(self.interpolated_pupil).mean()) / np.diff(self.interpolated_pupil).std()
+        # self.peaks = myfuncs.detect_peaks(self.pupil_diff, mph=10, mpd=500, threshold=None, edge='rising', kpsh=False, valley=False, show=False, ax=False)[:-1] # last peak might not reflect blink...
+        # if self.peaks != None:
+        #     points_for_interpolation = np.array([self.peaks, self.peaks], dtype=int).T + np.array(lin_interpolation_points).T
+        #     for itp in points_for_interpolation:
+        #         self.interpolated_pupil[itp[0]:itp[-1]] = np.linspace(self.interpolated_pupil[itp[0]], self.interpolated_pupil[itp[-1]], itp[-1]-itp[0])
+        #         self.interpolated_x[itp[0]:itp[-1]] = np.linspace(self.interpolated_x[itp[0]], self.interpolated_x[itp[-1]], itp[-1]-itp[0])
+        #         self.interpolated_y[itp[0]:itp[-1]] = np.linspace(self.interpolated_y[itp[0]], self.interpolated_y[itp[-1]], itp[-1]-itp[0])
+        
+        self.interpolated_time_points = np.zeros(len(self.interpolated_pupil))
+        self.pupil_diff = (np.diff(self.interpolated_pupil) - np.diff(self.interpolated_pupil).mean()) / np.diff(self.interpolated_pupil).std()
+        peaks_down = detect_peaks(self.pupil_diff, mph=10, mpd=1, threshold=None, edge='rising', kpsh=False, valley=False, show=False, ax=False)
+        peaks_up = detect_peaks(self.pupil_diff*-1, mph=10, mpd=1, threshold=None, edge='rising', kpsh=False, valley=False, show=False, ax=False)
+        self.peaks = np.sort(np.concatenate((peaks_down, peaks_up)))
+        
+        if len(self.peaks) > 0:
+            
+            # prepare:
+            self.peak_starts = np.sort(np.concatenate((self.peaks-1, self.blink_starts)))
+            self.peak_ends = np.sort(np.concatenate((self.peaks+1, self.blink_ends)))
+            start_indices = np.ones(self.peak_starts.shape[0], dtype=bool)
+            end_indices = np.ones(self.peak_ends.shape[0], dtype=bool)
+            for i in range(self.peak_starts.shape[0]):
+                try:
+                    if self.peak_starts[i+1] - self.peak_ends[i] <= coalesce_period:
+                        start_indices[i+1] = False
+                        end_indices[i] = False
+                except IndexError:
+                    pass
+            self.peak_starts = self.peak_starts[start_indices]
+            self.peak_ends = self.peak_ends[end_indices] 
+            
+            # interpolate:
+            points_for_interpolation = np.array([self.peak_starts, self.peak_ends], dtype=int).T + np.array(lin_interpolation_points).T
+            for itp in points_for_interpolation:
+                self.interpolated_pupil[itp[0]:itp[-1]] = np.linspace(self.interpolated_pupil[itp[0]], self.interpolated_pupil[itp[-1]], itp[-1]-itp[0])
+                self.interpolated_x[itp[0]:itp[-1]] = np.linspace(self.interpolated_x[itp[0]], self.interpolated_x[itp[-1]], itp[-1]-itp[0])
+                self.interpolated_y[itp[0]:itp[-1]] = np.linspace(self.interpolated_y[itp[0]], self.interpolated_y[itp[-1]], itp[-1]-itp[0])
+                self.interpolated_time_points[itp[0]:itp[-1]] = 1
+                     
+    def filter_pupil(self, hp = 0.01, lp = 10.0):
+        """
+        band_pass_filter_pupil band pass filters the pupil signal using a butterworth filter of order 3. 
+        
+        The results are stored in self.lp_filt_pupil, self.hp_filt_pupil and self.bp_filt_pupil
+        
+        This method is typically called after self.interpolateblinks() and, optionally, self.interpolateblinks2(),
+        consistent with the fact that this method expects the self.interpolated_... variables to exist.
+        """
+        self.logger.info('Band-pass filtering of pupil signals, hp = %2.3f, lp = %2.3f'%(hp, lp))
+        
+        self.lp_filt_pupil = _butter_lowpass(data=self.interpolated_pupil.astype('float64'), highcut=lp, fs=self.sample_rate, order=3)
+        self.hp_filt_pupil = _butter_highpass(data=self.interpolated_pupil.astype('float64'), lowcut=hp, fs=self.sample_rate, order=3)
+        self.bp_filt_pupil = self.hp_filt_pupil - (self.interpolated_pupil-self.lp_filt_pupil)
+        self.baseline_filt_pupil = self.lp_filt_pupil - self.bp_filt_pupil
+        
+        # import mne
+        # from mne import filter
+        # self.lp_filt_pupil = mne.filter.low_pass_filter(x=self.interpolated_pupil.astype('float64'), Fs=self.sample_rate, Fp=lp, filter_length=None, method='iir', iir_params={'ftype':'butter', 'order':3}, picks=None, n_jobs=1, copy=True, verbose=None)
+        # self.hp_filt_pupil = mne.filter.high_pass_filter(x=self.interpolated_pupil.astype('float64'), Fs=self.sample_rate, Fp=hp, filter_length=None, method='iir', iir_params={'ftype':'butter', 'order':3}, picks=None, n_jobs=1, copy=True, verbose=None)
+        # self.bp_filt_pupil = self.hp_filt_pupil - (self.interpolated_pupil-self.lp_filt_pupil)
+        # self.baseline_filt_pupil = self.lp_filt_pupil - self.bp_filt_pupil
+                
+    def zscore_pupil(self, dtype = 'bp_filt_pupil'):
+        """
+        zscore_pupil takes z-score of the dtype pupil signal, and internalizes it as a dtype + '_zscore' self variable.
+        """
+        
+        exec('self.' + str(dtype) + '_zscore = (self.' + str(dtype) + ' - np.mean(self.' + str(dtype) + ')) / np.std(self.' + str(dtype) + ')')
+        
+    def percent_signal_change_pupil(self, dtype = 'bp_filt_pupil'):
+        """
+        percent_signal_change_pupil takes percent signal change of the dtype pupil signal, and internalizes it as a dtype + '_psc' self variable.
+        """
+        
+        exec('self.{}_psc = ((self.{} - self.{}.mean()) / np.mean(self.baseline_filt_pupil[500:-500])) * 100'.format(dtype, dtype, dtype))
+        
+    def dt_pupil(self, dtype = 'bp_filt_pupil'):
+        """
+        dt_pupil takes the temporal derivative of the dtype pupil signal, and internalizes it as a dtype + '_dt' self variable.
+        """
+        
+        exec('self.' + str(dtype) + '_dt = np.r_[0, np.diff(self.' + str(dtype) + ')]' )
 
-		After calling this method, additional interpolation may be performed by calling self.interpolate_blinks2()
-		"""
-		self.logger.info('Interpolating blinks using interpolate_blinks')
-		# set all missing data to 0:
-		self.raw_pupil[self.raw_pupil<threshold_level] = 0
-		
-		# blinks to work with -- preferably eyelink!
-		if hasattr(self, 'eyelink_blink_data'):
-			for i in range(len(self.blink_starts_EL)):
-				self.raw_pupil[self.blink_starts_EL[i]:self.blink_ends_EL[i]] = 0 # set all eyelink-identified blinks to 0:
-		else:
-			self.blinks_indices = pd.rolling_mean(np.array(self.raw_pupil == 0, dtype = float), int(coalesce_period)) > 0
-			self.blinks_indices = np.array(self.blinks_indices, dtype=int)
-			self.blink_starts = self.timepoints[:-1][np.diff(self.blinks_indices) == 1]
-			self.blink_ends = self.timepoints[:-1][np.diff(self.blinks_indices) == -1]
-			# now make sure we're only looking at the blnks that fall fully inside the data stream
-			try:
-				if self.blink_starts[0] > self.blink_ends[0]:
-					self.blink_ends = self.blink_ends[1:]
-				if self.blink_starts[-1] > self.blink_ends[-1]:
-					self.blink_starts = self.blink_starts[:-1]
-			except:
-				print('probably not enough blinks to do full checks in this recording')
-		
-		# we do not want to start or end with a 0:
-		import copy
-		self.interpolated_pupil = copy.copy(self.raw_pupil[:])
-		self.interpolated_x = copy.copy(self.raw_gaze_X)
-		self.interpolated_y = copy.copy(self.raw_gaze_Y)
-		self.interpolated_pupil[:coalesce_period*2] = max(np.percentile(self.interpolated_pupil[:int(self.sample_rate*2.5)], 90), np.percentile(self.interpolated_pupil, 50))
-		self.interpolated_pupil[-coalesce_period:] = max(np.percentile(self.interpolated_pupil[-int(self.sample_rate*2.5):], 90), np.percentile(self.interpolated_pupil, 50))
-		self.interpolated_x[:coalesce_period*2] = np.percentile(self.interpolated_x[:int(self.sample_rate*2.5)], 50)
-		self.interpolated_x[-coalesce_period:] = np.percentile(self.interpolated_x[-int(self.sample_rate*2.5):], 50)
-		self.interpolated_y[:coalesce_period*2] = np.percentile(self.interpolated_y[:int(self.sample_rate*2.5)], 50)
-		self.interpolated_y[-coalesce_period:] = np.percentile(self.interpolated_y[-int(self.sample_rate*2.5):], 50)
-		
-		# detect zero edges (we just created from blinks, plus missing data):
-		zero_edges = np.arange(self.interpolated_pupil.shape[0])[np.diff((self.interpolated_pupil<1))]
-		if zero_edges.shape[0] == 0:
-			pass
-		else:
-			zero_edges = zero_edges[:int(2 * np.floor(zero_edges.shape[0]/2.0))].reshape(-1,2)
-		
-		self.blink_starts = zero_edges[:,0]
-		self.blink_ends = zero_edges[:,1]
-		
-		# check for neighbouring blinks (coalesce_period, default is 500ms), and string them together:
-		start_indices = np.ones(self.blink_starts.shape[0], dtype=bool)
-		end_indices = np.ones(self.blink_ends.shape[0], dtype=bool)
-		for i in range(self.blink_starts.shape[0]):
-			try:
-				if self.blink_starts[i+1] - self.blink_ends[i] <= coalesce_period:
-					start_indices[i+1] = False
-					end_indices[i] = False
-			except IndexError:
-				pass
-		
-		# these are the blink start and end samples to work with:
-		if sum(start_indices) > 0:
-			self.blink_starts = self.blink_starts[start_indices]
-			self.blink_ends = self.blink_ends[end_indices]
-		else:
-			self.blink_starts = None
-			self.blink_ends = None
-		self.blink_starts = self.blink_starts[self.blink_starts>coalesce_period]
-		self.blink_ends = self.blink_ends[self.blink_starts>coalesce_period]
-		
-		# do actual interpolation:
-		if method == 'spline':
-			points_for_interpolation = np.array(np.array(spline_interpolation_points) * self.sample_rate, dtype = int)
-			for bs, be in zip(self.blink_starts, self.blink_ends):
-				samples = np.ravel(np.array([bs + points_for_interpolation[0], be + points_for_interpolation[1]]))
-				sample_indices = np.arange(self.raw_pupil.shape[0])[np.sum(np.array([self.timepoints == s for s in samples]), axis = 0)]
-				spline = interpolate.InterpolatedUnivariateSpline(sample_indices,self.raw_pupil[sample_indices])
-				self.interpolated_pupil[sample_indices[0]:sample_indices[-1]] = spline(np.arange(sample_indices[1],sample_indices[-2]))
-				spline = interpolate.InterpolatedUnivariateSpline(sample_indices,self.raw_gaze_X[sample_indices])
-				self.interpolated_x[sample_indices[0]:sample_indices[-1]] = spline(np.arange(sample_indices[1],sample_indices[-2]))
-				spline = interpolate.InterpolatedUnivariateSpline(sample_indices,self.raw_gaze_Y[sample_indices])
-				self.interpolated_y[sample_indices[0]:sample_indices[-1]] = spline(np.arange(sample_indices[1],sample_indices[-2]))
-		elif method == 'linear':
-			if self.blink_starts != None:
-				points_for_interpolation = np.array([self.blink_starts, self.blink_ends], dtype=int).T + np.array(lin_interpolation_points).T
-				for itp in points_for_interpolation:
-					self.interpolated_pupil[itp[0]:itp[-1]] = np.linspace(self.interpolated_pupil[itp[0]], self.interpolated_pupil[itp[-1]], itp[-1]-itp[0])
-					self.interpolated_x[itp[0]:itp[-1]] = np.linspace(self.interpolated_x[itp[0]], self.interpolated_x[itp[-1]], itp[-1]-itp[0])
-					self.interpolated_y[itp[0]:itp[-1]] = np.linspace(self.interpolated_y[itp[0]], self.interpolated_y[itp[-1]], itp[-1]-itp[0])
-					
-	def interpolate_blinks2(self, lin_interpolation_points = [[-100],[100]]):
-		
-		"""
-		interpolate_blinks2 performs linear interpolation around peaks in the rate of change of
-		the pupil size.
-		
-		The results are stored in self.interpolated_pupil, self.interpolated_x and self.interpolated_y
-		without affecting the self.raw_... variables.
-		
-		This method is typically called after an initial interpolation using self.interpolateblinks(),
-		consistent with the fact that this method expects the self.interpolated_... variables to already exist.
-		"""
-		
-		self.pupil_diff = (np.diff(self.interpolated_pupil) - np.diff(self.interpolated_pupil).mean()) / np.diff(self.interpolated_pupil).std()
-		self.peaks = detect_peaks(self.pupil_diff, mph=10, mpd=500, threshold=None, edge='rising', kpsh=False, valley=False, show=False, ax=False)[:-1] # last peak might not reflect blink...
-		if self.peaks != None:
-			points_for_interpolation = np.array([self.peaks, self.peaks], dtype=int).T + np.array(lin_interpolation_points).T
-			for itp in points_for_interpolation:
-				self.interpolated_pupil[itp[0]:itp[-1]] = np.linspace(self.interpolated_pupil[itp[0]], self.interpolated_pupil[itp[-1]], itp[-1]-itp[0])
-				self.interpolated_x[itp[0]:itp[-1]] = np.linspace(self.interpolated_x[itp[0]], self.interpolated_x[itp[-1]], itp[-1]-itp[0])
-				self.interpolated_y[itp[0]:itp[-1]] = np.linspace(self.interpolated_y[itp[0]], self.interpolated_y[itp[-1]], itp[-1]-itp[0])
-			
-	def filter_pupil(self, hp = 0.01, lp = 4.0):
-		"""
-		band_pass_filter_pupil band pass filters the pupil signal using a butterworth filter of order 3. 
-		
-		The results are stored in self.lp_filt_pupil, self.hp_filt_pupil and self.bp_filt_pupil
-		
-		This method is typically called after self.interpolateblinks() and, optionally, self.interpolateblinks2(),
-		consistent with the fact that this method expects the self.interpolated_... variables to exist.
-		"""
-		self.logger.info('Band-pass filtering of pupil signals, hp = %2.3f, lp = %2.3f'%(hp, lp))
+    def time_frequency_decomposition_pupil(self, 
+                                           minimal_frequency = 0.0025, 
+                                           maximal_frequency = 0.1, 
+                                           nr_freq_bins = 7, 
+                                           n_cycles = 1, 
+                                           cycle_buffer = 3, 
+                                           tf_decomposition='lp_butterworth'): 
+        """time_frequency_decomposition_pupil has two options of time frequency decomposition on the pupil  data: 1) morlet wavelet transform from mne package 
+            or 2) low-pass butterworth filters. Before tf-decomposition the minimal frequency in the data is compared to the input minimal_frequency using np.fft.fftfreq. 
+            
+            1) Morlet wavelet transform. Interpolated pupil data is z-scored and zero-padded to avoid edge artifacts during wavelet transformation. After morlet 
+            transform, zero-padding is removed and transformed data is saved in a DataFrame self.band_pass_filter_bank_pupil with wavelet frequencies as columns.
+            
+            2) Low-pass butterworth filters. Low-pass cutoff samples are calculated for each frequency in frequencies. Low-pass filtering is performed and saved in 
+            lp_filter_bank_pupil. Note: low-pass filtered signals are not yet band-pass here, thus, filtered signals with higher frequency cutoffs share lower frequency 
+            information at that point. band_pass_signals calculates the difference between subsequent lp_filter_bank_pupil signals to make independent filter bands and 
+            vstacks the lowest frequency to the datamatrix. Lastly, band_pass_signals are saved in a df in self.band_pass_filter_bank_pupil with low-pass frequencies as columns. 
+            """
+        
+        # check minimal frequency
+        min_freq_in_data = np.fft.fftfreq(self.timepoints.shape[0], 1.0/self.sample_rate)[1] 
+        if minimal_frequency < min_freq_in_data and minimal_frequency != None:
+            self.logger.warning("""time_frequency_decomposition_pupil: 
+                                    requested minimal_frequency %2.5f smaller than 
+                                    data allows (%2.5f). """%(minimal_frequency, min_freq_in_data))
 
-		# band-pass filtering of signal, high pass first and then low-pass
-		# High pass:
-		hp_cof_sample = hp / (self.interpolated_pupil.shape[0] / self.sample_rate / 2)
-		bhp, ahp = sp.signal.butter(3, hp_cof_sample, btype='high')
-		self.hp_filt_pupil = sp.signal.filtfilt(bhp, ahp, self.interpolated_pupil)
-		# Low pass:
-		lp_cof_sample = lp / (self.interpolated_pupil.shape[0] / self.sample_rate / 2)
-		blp, alp = sp.signal.butter(3, lp_cof_sample)
-		self.lp_filt_pupil = sp.signal.filtfilt(blp, alp, self.interpolated_pupil)
-		# Band pass:
-		self.bp_filt_pupil = sp.signal.filtfilt(blp, alp, self.hp_filt_pupil)
-		
-		# we may also add a baseline variable which contains the baseine 
-		# by doing 3rd order savitzky-golay filtering, with a width of ~100 s
-		# we dan use this baseline signal for correlations of phasic and tonic pupil responses, for example
-		
-		# self.baseline_filt_pupil = savitzky_golay(self.interpolated_pupil, self.sample_rate / (hp * 0.25), 3)
-		self.baseline_filt_pupil = self.lp_filt_pupil - self.bp_filt_pupil
-		
-	def zscore_pupil(self, dtype = 'bp_filt_pupil'):
-		"""
-		zscore_pupil z-scores the low-pass filtered pupil size data and the band-pass filtered pupil size data.
-		
-		The results are stored in self.bp_filt_pupil_zscore and self.lp_filt_pupil_zscore.
-		
-		This method is typically called after self.filter_pupil(), consistent with the fact that it
-		expects the self.[...]_filt_pupil variables to exist.
-		"""
-		
-		# self.bp_filt_pupil_clean_zscore = (self.bp_filt_pupil_clean - self.bp_filt_pupil_clean.mean()) / self.bp_filt_pupil_clean.std()
-		# self.bp_filt_pupil_zscore = (self.bp_filt_pupil - self.bp_filt_pupil.mean()) / self.bp_filt_pupil.std()
-		# self.lp_filt_pupil_zscore = (self.lp_filt_pupil - self.lp_filt_pupil.mean()) / self.lp_filt_pupil.std()
-		# self.baseline_filt_pupil_zscore = (self.baseline_filt_pupil - self.baseline_filt_pupil.mean()) / self.baseline_filt_pupil.std()
-		
-		exec('self.' + str(dtype) + '_zscore = (self.' + str(dtype) + ' - np.mean(self.' + str(dtype) + ')) / np.std(self.' + str(dtype) + ')')
-		
-	def percent_signal_change_pupil(self, dtype = 'bp_filt_pupil'):
-		"""
-		percent_signal_change_pupil takes percent signal change of the dtype pupil signal, and internalizes it as a dtype + '_psc' self variable.
-		"""
-		
-		exec('self.' + str(dtype) + '_psc = ((self.' + str(dtype) + ' / np.mean(self.baseline_filt_pupil[2000:-2000])) * 100) - 100' )
-		
-		
-	def dt_pupil(self, dtype = 'bp_filt_pupil'):
-		"""
-		dt_pupil takes the temporal derivative of the dtype pupil signal, and internalizes it as a dtype + '_dt' self variable.
-		"""
-		
-		exec('self.' + str(dtype) + '_dt = np.r_[0, np.diff(self.' + str(dtype) + ')]' )		
+        if minimal_frequency == None:
+            minimal_frequency = min_freq_in_data
 
-	def time_frequency_decomposition_pupil(self, 
-										   minimal_frequency = 0.0025, 
-										   maximal_frequency = 0.1, 
-										   nr_freq_bins = 7, 
-										   n_cycles = 1, 
-										   cycle_buffer = 3, 
-										   tf_decomposition='lp_butterworth'): 
-		"""time_frequency_decomposition_pupil has two options of time frequency decomposition on the pupil  data: 1) morlet wavelet transform from mne package 
-			or 2) low-pass butterworth filters. Before tf-decomposition the minimal frequency in the data is compared to the input minimal_frequency using np.fft.fftfreq. 
-			
-			1) Morlet wavelet transform. Interpolated pupil data is z-scored and zero-padded to avoid edge artifacts during wavelet transformation. After morlet 
-			transform, zero-padding is removed and transformed data is saved in a DataFrame self.band_pass_filter_bank_pupil with wavelet frequencies as columns.
-			
-			2) Low-pass butterworth filters. Low-pass cutoff samples are calculated for each frequency in frequencies. Low-pass filtering is performed and saved in 
-			lp_filter_bank_pupil. Note: low-pass filtered signals are not yet band-pass here, thus, filtered signals with higher frequency cutoffs share lower frequency 
-			information at that point. band_pass_signals calculates the difference between subsequent lp_filter_bank_pupil signals to make independent filter bands and 
-			vstacks the lowest frequency to the datamatrix. Lastly, band_pass_signals are saved in a df in self.band_pass_filter_bank_pupil with low-pass frequencies as columns. 
-			"""
-		
-		# check minimal frequency
-		min_freq_in_data = np.fft.fftfreq(self.timepoints.shape[0], 1.0/self.sample_rate)[1] 
-		if minimal_frequency < min_freq_in_data and minimal_frequency != None:
-			self.logger.warning("""time_frequency_decomposition_pupil: 
-									requested minimal_frequency %2.5f smaller than 
-									data allows (%2.5f). """%(minimal_frequency, min_freq_in_data))
+        # use minimal_frequency for bank of logarithmically frequency-spaced filters
+        frequencies = np.logspace(np.log10(maximal_frequency), np.log10(minimal_frequency), nr_freq_bins)
+        self.logger.info('Time_frequency_decomposition_pupil, with filterbank %s'%str(frequencies))
+    
+        if tf_decomposition == 'morlet': 
+            #z-score self.interpolated_pupil before morlet decomposition of pupil signal 
+            interpolated_pupil_z = ((self.interpolated_pupil - np.mean(self.interpolated_pupil))/self.interpolated_pupil.std())
+            #zero-pad runs to avoid edge-artifacts 
+            zero_padding_samples = int((1/minimal_frequency)*self.sample_rate*cycle_buffer)
+            padded_interpolated_pupil_z = np.zeros((interpolated_pupil_z.shape[0] + 2*(zero_padding_samples)))
+            padded_interpolated_pupil_z[zero_padding_samples:-zero_padding_samples] = interpolated_pupil_z    
+            #filtered signal is real part of Morlet-transformed signal
+            padded_band_pass_filter_bank_pupil = np.squeeze(np.real(mne.time_frequency.cwt_morlet(padded_interpolated_pupil_z[np.newaxis,:], self.sample_rate, frequencies, use_fft=True, n_cycles=n_cycles, zero_mean=True)))
+            #remove zero-padding and save as dataframe with frequencies as index
+            self.band_pass_filter_bank_pupil = pd.DataFrame(np.array([padded_band_pass_filter_bank_pupil[i][zero_padding_samples:-zero_padding_samples] for i in range(len(padded_band_pass_filter_bank_pupil))]).T,columns=frequencies)
+        
+        elif tf_decomposition == 'lp_butterworth': 
+            lp_filter_bank_pupil=np.zeros((len(frequencies), self.interpolated_pupil.shape[0]))
+            lp_cof_samples = [freq / (self.interpolated_pupil.shape[0] / self.sample_rate / 2) for freq in frequencies]
+            for i, lp_cutoff in enumerate(lp_cof_samples): 
+                blp, alp = sp.signal.butter(3, lp_cutoff) 
+                lp_filt_pupil = sp.signal.filtfilt(blp, alp, self.interpolated_pupil)
+                lp_filter_bank_pupil[i,0:self.interpolated_pupil.shape[0]]=lp_filt_pupil
+            #calculate band passes from the difference between subsequent low pass frequencies (except the last frequency, this one is directly added to the df as the lowest freq in data) 
+            band_pass_signals = np.vstack((np.array(lp_filter_bank_pupil[:-1]) - np.array(lp_filter_bank_pupil[1:]), lp_filter_bank_pupil[-1]))
+            self.band_pass_filter_bank_pupil = pd.DataFrame(band_pass_signals.T, columns=frequencies)
+        
+        else: 
+            print('you did not specify a tf-decomposition')
+    
 
-		if minimal_frequency == None:
-			minimal_frequency = min_freq_in_data
+    def regress_blinks(self, interval=7):
+        """
+        """
+        self.logger.info('Regressing blinks, saccades and gaze position of pupil signals')
+        # params:
+        
+        self.downsample_rate = 100
+        self.new_sample_rate = self.sample_rate / self.downsample_rate
+        
+        x = np.linspace(0, interval, interval * self.sample_rate, endpoint=False)
+        
+        # events:
+        blinks = self.blink_ends
+        blinks = blinks[blinks>25]
+        blinks = blinks[blinks<((self.timepoints[-1]-self.timepoints[0]))-interval]
+        
+        if blinks.size == 0:
+            blinks = np.array([0], dtype = int)
+        else:
+            blinks = blinks.astype(int)
+        
+        sacs = self.sac_ends_EL
+        sacs = sacs[sacs>25]
+        sacs = sacs[sacs<((self.timepoints[-1]-self.timepoints[0]))-interval]
+        sacs = sacs.astype(int)
+        
+        def double_gamma(params, x): 
+            a1 = params['a1']
+            sh1 = params['sh1']
+            sc1 = params['sc1']
+            a2 = params['a2']
+            sh2 = params['sh2']
+            sc2 = params['sc2']
+            return a1 * sp.stats.gamma.pdf(x, sh1, loc=0.0, scale = sc1) + a2 * sp.stats.gamma.pdf(x, sh2, loc=0.0, scale=sc2)
+    
+        # use standard values:
+        standard_blink_parameters = {'a1':-0.604, 'sh1':8.337, 'sc1':0.115, 'a2':0.419, 'sh2':15.433, 'sc2':0.178}
+        self.blink_kernel = double_gamma(standard_blink_parameters, x)
 
-		# use minimal_frequency for bank of logarithmically frequency-spaced filters
-		frequencies = np.logspace(np.log10(maximal_frequency), np.log10(minimal_frequency), nr_freq_bins)
-		self.logger.info('Time_frequency_decomposition_pupil, with filterbank %s'%str(frequencies))
-	
-		if tf_decomposition == 'morlet': 
-			#z-score self.interpolated_pupil before morlet decomposition of pupil signal 
-			interpolated_pupil_z = ((self.interpolated_pupil - np.mean(self.interpolated_pupil))/self.interpolated_pupil.std())
-			#zero-pad runs to avoid edge-artifacts 
-			zero_padding_samples = int((1/minimal_frequency)*self.sample_rate*cycle_buffer)
-			padded_interpolated_pupil_z = np.zeros((interpolated_pupil_z.shape[0] + 2*(zero_padding_samples)))
-			padded_interpolated_pupil_z[zero_padding_samples:-zero_padding_samples] = interpolated_pupil_z	
-			#filtered signal is real part of Morlet-transformed signal
-			padded_band_pass_filter_bank_pupil = np.squeeze(np.real(mne.time_frequency.cwt_morlet(padded_interpolated_pupil_z[np.newaxis,:], self.sample_rate, frequencies, use_fft=True, n_cycles=n_cycles, zero_mean=True)))
-			#remove zero-padding and save as dataframe with frequencies as index
-			self.band_pass_filter_bank_pupil = pd.DataFrame(np.array([padded_band_pass_filter_bank_pupil[i][zero_padding_samples:-zero_padding_samples] for i in range(len(padded_band_pass_filter_bank_pupil))]).T,columns=frequencies)
-		
-		elif tf_decomposition == 'lp_butterworth': 
-			lp_filter_bank_pupil=np.zeros((len(frequencies), self.interpolated_pupil.shape[0]))
-			lp_cof_samples = [freq / (self.interpolated_pupil.shape[0] / self.sample_rate / 2) for freq in frequencies]
-			for i, lp_cutoff in enumerate(lp_cof_samples): 
-				blp, alp = sp.signal.butter(3, lp_cutoff) 
-				lp_filt_pupil = sp.signal.filtfilt(blp, alp, self.interpolated_pupil)
-				lp_filter_bank_pupil[i,0:self.interpolated_pupil.shape[0]]=lp_filt_pupil
-			#calculate band passes from the difference between subsequent low pass frequencies (except the last frequency, this one is directly added to the df as the lowest freq in data) 
-			band_pass_signals = np.vstack((np.array(lp_filter_bank_pupil[:-1]) - np.array(lp_filter_bank_pupil[1:]), lp_filter_bank_pupil[-1]))
-			self.band_pass_filter_bank_pupil = pd.DataFrame(band_pass_signals.T, columns=frequencies)
-		
-		else: 
-			print('you did not specify a tf-decomposition')
-	
-	def regress_blinks(self, interval = 7):
-		"""
-		"""
-		self.logger.info('Regressing blinks, saccades and gaze position of pupil signals')
-		# params:
-		
-		x = np.linspace(0, interval, interval * self.sample_rate, endpoint=False)
-				
-		# events:
-		blinks = self.blink_ends
-		blinks = blinks[blinks>25]
-		blinks = blinks[blinks<((self.timepoints[-1]-self.timepoints[0]))-interval]
-		
-		if blinks.size == 0:
-			blinks = np.array([0], dtype = int)
-		else:
-			blinks = blinks.astype(int)
-		
-		sacs = self.sac_ends_EL
-		sacs = sacs[sacs>25]
-		sacs = sacs[sacs<((self.timepoints[-1]-self.timepoints[0]))-interval]
-		sacs = sacs.astype(int)
+        standard_sac_parameters = {'a1':-0.175, 'sh1': 6.451, 'sc1':0.178, 'a2':0.0, 'sh2': 1, 'sc2': 1}
+        self.sac_kernel = double_gamma(standard_sac_parameters, x)
+                
+        # blink and saccade regressors:
+        blink_reg = np.zeros(self.bp_filt_pupil.shape[0])
+        blink_reg[blinks] = 1
+        blink_reg_conv = sp.signal.fftconvolve(blink_reg, self.blink_kernel, 'full')[:-(len(self.blink_kernel)-1)]
+        sac_reg = np.zeros(self.bp_filt_pupil.shape[0])
+        sac_reg[sacs] = 1
+        sac_reg_conv = sp.signal.fftconvolve(sac_reg, self.sac_kernel, 'full')[:-(len(self.sac_kernel)-1)]
 
-		def double_gamma(params, x): 
-			a1 = params['a1']
-			sh1 = params['sh1']
-			sc1 = params['sc1']
-			a2 = params['a2']
-			sh2 = params['sh2']
-			sc2 = params['sc2']
-			return a1 * sp.stats.gamma.pdf(x, sh1, loc=0.0, scale = sc1) + a2 * sp.stats.gamma.pdf(x, sh2, loc=0.0, scale = sc2)
-	
-		# use standard values:
-		standard_blink_parameters = {'a1':-0.604, 'sh1':8.337, 'sc1':0.115, 'a2':0.419, 'sh2':15.433, 'sc2':0.178}
-		blink_kernel = double_gamma(standard_blink_parameters, x)
+        # high-pass filter the eye position data to remove slow drifts
+        hp_cof_sample = 0.005 / (self.interpolated_x.shape[0] / self.sample_rate / 2)
+        bhp, ahp = sp.signal.butter(3, hp_cof_sample, btype='high')
+        interpolated_x_hp = sp.signal.filtfilt(bhp, ahp, self.interpolated_x)
+        interpolated_y_hp = sp.signal.filtfilt(bhp, ahp, self.interpolated_y)
 
-		standard_sac_parameters = {'a1':-0.175, 'sh1': 6.451, 'sc1':0.178, 'a2':0.0, 'sh2': 1, 'sc2': 1}
-		sac_kernel = double_gamma(standard_sac_parameters, x)
-				
-		# blink and saccade regressors:
-		blink_reg = np.zeros(self.bp_filt_pupil.shape[0])
-		blink_reg[blinks] = 1
-		blink_reg_conv = sp.signal.fftconvolve(blink_reg, blink_kernel, 'full')[:-(len(blink_kernel)-1)]
-		sac_reg = np.zeros(self.bp_filt_pupil.shape[0])
-		sac_reg[sacs] = 1
-		sac_reg_conv = sp.signal.fftconvolve(sac_reg, sac_kernel, 'full')[:-(len(sac_kernel)-1)]
+        # we add x and y gaze position for foreshortening, and add intercept
+        regs = [blink_reg_conv, sac_reg_conv, interpolated_x_hp, interpolated_y_hp, np.ones(sac_reg_conv.shape[-1]) ]
+        print([r.shape for r in regs])
 
-		# high-pass filter the eye position data to remove slow drifts
-		hp_cof_sample = 0.005 / (self.interpolated_x.shape[0] / self.sample_rate / 2)
-		bhp, ahp = sp.signal.butter(3, hp_cof_sample, btype='high')
-		interpolated_x_hp = sp.signal.filtfilt(bhp, ahp, self.interpolated_x)
-		interpolated_y_hp = sp.signal.filtfilt(bhp, ahp, self.interpolated_y)
+        # GLM:
+        design_matrix = np.matrix(np.vstack([reg for reg in regs])).T
+        betas = np.array(((design_matrix.T * design_matrix).I * design_matrix.T) * np.matrix(self.bp_filt_pupil).T).ravel()
+        explained = np.sum(np.vstack([betas[i]*regs[i] for i in range(len(betas))]), axis=0)
+        
+        rsq = sp.stats.pearsonr(self.bp_filt_pupil, explained)
+        self.logger.info('Nuisance GLM Results, pearsons R (p) is %1.3f (%1.4f)'%(rsq))
+        self.logger.info('Nuisance GLM Results, Blink, Saccade beta %3.3f, %3.3f)'%(betas[0], betas[1]))
+        self.logger.info('Nuisance GLM Results, Gaze x, y, intercept beta %3.3f, %3.3f, %3.3f )'%(betas[2], betas[3], betas[4]))
 
-		# we add x and y gaze position for foreshortening, and add intercept
-		regs = [blink_reg_conv, sac_reg_conv, interpolated_x_hp, interpolated_y_hp, np.ones(sac_reg_conv.shape[-1]) ]
-		print([r.shape for r in regs])
+        # clean data are residuals:
+        self.bp_filt_pupil_clean = self.bp_filt_pupil - explained
+        
+        # final timeseries:
+        self.lp_filt_pupil_clean = self.bp_filt_pupil_clean + self.baseline_filt_pupil
+        self.bp_filt_pupil_clean = self.bp_filt_pupil_clean + self.baseline_filt_pupil.mean()
+        
+    def summary_plot(self):
+        
+        import matplotlib.gridspec as gridspec
+        
+        fig = plt.figure(figsize=(6,10))
+        gs = gridspec.GridSpec(5, 4)
+        ax1 = plt.subplot(gs[0,:])
+        ax2 = plt.subplot(gs[1,:])
+        ax3 = plt.subplot(gs[2,0:2])
+        ax4 = plt.subplot(gs[2,2:4])
+        ax5 = plt.subplot(gs[3,:])
+        ax6 = plt.subplot(gs[4,:])
+        
+        x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
+        ax1.plot(x, self.raw_pupil, 'b', rasterized=True)
+        ax1.plot(x, self.interpolated_pupil, 'g', rasterized=True)
+        ax1.set_title('Raw and blink interpolated timeseries')
+        ax1.set_ylabel('Pupil size (raw)')
+        ax1.set_xlabel('Time (s)')
+        ax1.legend(['Raw', 'Int + filt'])
+        
+        ax2.plot(self.pupil_diff, rasterized=True)
+        ax2.plot(self.peaks, self.pupil_diff[self.peaks], '+', mec='r', mew=2, ms=8, rasterized=True)
+        ax2.set_ylim(ymin=-200, ymax=200)
+        ax2.set_title('Remaining blinks?')
+        ax2.set_ylabel('Diff pupil size (raw)')
+        ax2.set_xlabel('Samples')
+        
+        x = np.linspace(0,self.blink_kernel.shape[0]/self.sample_rate, self.blink_kernel.shape[0])
+        # ax3.plot(x, self.blink_response, label='response')
+        ax3.plot(x, self.blink_kernel, label='fit')
+        ax3.legend()
+        ax3.set_title('Blink response')
+        ax3.set_xlabel('Time (s)')
+        ax3.set_ylabel('Pupil size (raw)')
+        
+        # ax4.plot(x, self.sac_response, label='response')
+        ax4.plot(x, self.sac_kernel, label='fit')
+        ax4.legend()
+        ax4.set_title('Saccade response')
+        ax4.set_xlabel('Time (s)')
+        ax4.set_ylabel('Pupil size (raw)')
 
-		# GLM:
-		design_matrix = np.matrix(np.vstack([reg for reg in regs])).T
-		betas = np.array(((design_matrix.T * design_matrix).I * design_matrix.T) * np.matrix(self.bp_filt_pupil).T).ravel()
-		explained = np.sum(np.vstack([betas[i]*regs[i] for i in range(len(betas))]), axis=0)
-		
-		rsq = sp.stats.pearsonr(self.bp_filt_pupil, explained)
-		self.logger.info('Nuisance GLM Results, pearsons R (p) is %1.3f (%1.4f)'%(rsq))
-		self.logger.info('Nuisance GLM Results, Blink, Saccade beta %3.3f, %3.3f)'%(betas[0], betas[1]))
-		self.logger.info('Nuisance GLM Results, Gaze x, y, intercept beta %3.3f, %3.3f, %3.3f )'%(betas[2], betas[3], betas[4]))
-
-		# clean data are residuals:
-		self.bp_filt_pupil_clean = self.bp_filt_pupil - explained
-		
-		# final timeseries:
-		self.lp_filt_pupil_clean = self.bp_filt_pupil_clean + self.baseline_filt_pupil
-		self.bp_filt_pupil_clean = self.bp_filt_pupil_clean + self.baseline_filt_pupil.mean()
-		
-	
-		
-		
-		
-	
-		
+        try:
+            x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
+            ax5.plot(x, self.GLM_measured, 'b', rasterized=True)
+            ax5.plot(x, self.GLM_predicted, lw=2, color='g', rasterized=True)
+            ax5.set_title('Nuisance GLM -- R2={}, p={}'.format(round(self.GLM_r,4), round(self.GLM_p,4)))
+            ax5.set_ylabel('Pupil size (raw)')
+            ax5.set_xlabel('Time (s)')
+            ax5.legend(['measured', 'predicted'])
+        except:
+            pass
+        
+        ax6.plot(x, self.lp_filt_pupil_psc, 'b', rasterized=True)
+        ax6.plot(x, self.lp_filt_pupil_clean_psc, 'g', rasterized=True)
+        ax6.set_title('Final timeseries')
+        ax6.set_ylabel('Pupil size (% signal change)')
+        ax6.set_xlabel('Time (s)')
+        ax6.legend(['low pass', 'low pass + cleaned up'])
+        
+        plt.tight_layout()
+        
+        return fig

--- a/src/EyeSignalOperator.py
+++ b/src/EyeSignalOperator.py
@@ -752,12 +752,12 @@ class EyeSignalOperator(Operator):
         ax1.set_xlabel('Time (min)')
         ax1.legend(['Raw', 'Int + filt'])
         
-        ax2.plot(self.pupil_diff, rasterized=True)
-        ax2.plot(self.peaks, self.pupil_diff[self.peaks], '+', mec='r', mew=2, ms=8, rasterized=True)
+        ax2.plot(x[1:], self.pupil_diff, rasterized=True)
+        ax2.plot(self.peaks/self.sample_rate/60.0, self.pupil_diff[self.peaks], '+', mec='r', mew=2, ms=8, rasterized=True)
         ax2.set_ylim(ymin=-200, ymax=200)
         ax2.set_title('Remaining blinks?')
         ax2.set_ylabel('Diff pupil size (raw)')
-        ax1.set_xlabel('Time (min)')
+        ax2.set_xlabel('Time (min)')
         
         x = np.linspace(0,self.blink_kernel.shape[0]/self.sample_rate, self.blink_kernel.shape[0])
         # ax3.plot(x, self.blink_response, label='response')
@@ -765,14 +765,14 @@ class EyeSignalOperator(Operator):
         ax3.legend()
         ax3.set_title('Blink response')
         ax3.set_xlabel('Time (s)')
-        ax3.set_ylabel('Pupil size (raw)')
+        ax3.set_ylabel('Pupil response (a.u.)')
         
         # ax4.plot(x, self.sac_response, label='response')
         ax4.plot(x, self.sac_kernel, label='fit')
         ax4.legend()
         ax4.set_title('Saccade response')
         ax4.set_xlabel('Time (s)')
-        ax4.set_ylabel('Pupil size (raw)')
+        ax4.set_ylabel('Pupil response (a.u.)')
         
         x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0]) / 60.0
         ax5.plot(x, self.lp_filt_pupil, 'b', rasterized=True)

--- a/src/EyeSignalOperator.py
+++ b/src/EyeSignalOperator.py
@@ -537,7 +537,7 @@ class EyeSignalOperator(Operator):
                 self.interpolated_y[itp[0]:itp[-1]] = np.linspace(self.interpolated_y[itp[0]], self.interpolated_y[itp[-1]], itp[-1]-itp[0])
                 self.interpolated_time_points[itp[0]:itp[-1]] = 1
                      
-    def filter_pupil(self, hp = 0.01, lp = 10.0):
+    def filter_pupil(self, hp=0.01, lp=10.0):
         """
         band_pass_filter_pupil band pass filters the pupil signal using a butterworth filter of order 3. 
         
@@ -667,6 +667,8 @@ class EyeSignalOperator(Operator):
         sacs = sacs[sacs<((self.timepoints[-1]-self.timepoints[0]))-interval]
         sacs = sacs.astype(int)
         
+        # shell()
+        
         def double_gamma(params, x): 
             a1 = params['a1']
             sh1 = params['sh1']
@@ -723,13 +725,13 @@ class EyeSignalOperator(Operator):
         import matplotlib.gridspec as gridspec
         
         fig = plt.figure(figsize=(6,10))
-        gs = gridspec.GridSpec(5, 4)
+        gs = gridspec.GridSpec(4, 2)
         ax1 = plt.subplot(gs[0,:])
         ax2 = plt.subplot(gs[1,:])
-        ax3 = plt.subplot(gs[2,0:2])
-        ax4 = plt.subplot(gs[2,2:4])
+        ax3 = plt.subplot(gs[2,0:1])
+        ax4 = plt.subplot(gs[2,1:2])
         ax5 = plt.subplot(gs[3,:])
-        ax6 = plt.subplot(gs[4,:])
+        # ax6 = plt.subplot(gs[4,:])
         
         x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
         ax1.plot(x, self.raw_pupil, 'b', rasterized=True)
@@ -761,23 +763,24 @@ class EyeSignalOperator(Operator):
         ax4.set_xlabel('Time (s)')
         ax4.set_ylabel('Pupil size (raw)')
 
-        try:
-            x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
-            ax5.plot(x, self.GLM_measured, 'b', rasterized=True)
-            ax5.plot(x, self.GLM_predicted, lw=2, color='g', rasterized=True)
-            ax5.set_title('Nuisance GLM -- R2={}, p={}'.format(round(self.GLM_r,4), round(self.GLM_p,4)))
-            ax5.set_ylabel('Pupil size (raw)')
-            ax5.set_xlabel('Time (s)')
-            ax5.legend(['measured', 'predicted'])
-        except:
-            pass
+        # try:
+        #     x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
+        #     ax5.plot(x, self.GLM_measured, 'b', rasterized=True)
+        #     ax5.plot(x, self.GLM_predicted, lw=2, color='g', rasterized=True)
+        #     ax5.set_title('Nuisance GLM -- R2={}, p={}'.format(round(self.GLM_r,4), round(self.GLM_p,4)))
+        #     ax5.set_ylabel('Pupil size (raw)')
+        #     ax5.set_xlabel('Time (s)')
+        #     ax5.legend(['measured', 'predicted'])
+        # except:
+        #     pass
         
-        ax6.plot(x, self.lp_filt_pupil_psc, 'b', rasterized=True)
-        ax6.plot(x, self.lp_filt_pupil_clean_psc, 'g', rasterized=True)
-        ax6.set_title('Final timeseries')
-        ax6.set_ylabel('Pupil size (% signal change)')
-        ax6.set_xlabel('Time (s)')
-        ax6.legend(['low pass', 'low pass + cleaned up'])
+        x = np.linspace(0,self.raw_pupil.shape[0]/self.sample_rate, self.raw_pupil.shape[0])
+        ax5.plot(x, self.lp_filt_pupil, 'b', rasterized=True)
+        ax5.plot(x, self.lp_filt_pupil_clean, 'g', rasterized=True)
+        ax5.set_title('Final timeseries')
+        ax5.set_ylabel('Pupil size (% signal change)')
+        ax5.set_xlabel('Time (s)')
+        ax5.legend(['low pass', 'low pass + cleaned up'])
         
         plt.tight_layout()
         

--- a/src/HDFEyeOperator.py
+++ b/src/HDFEyeOperator.py
@@ -156,6 +156,8 @@ class HDFEyeOperator(Operator):
             pupil_lp = 6,
             sample_rate = 1000.,
             normalization = 'psc',
+            regress_blinks = True,
+            regress_sacs = True,
             minimal_frequency_filterbank = 0.0025, 
             maximal_frequency_filterbank = 0.1, 
             nr_freq_bins_filterbank = 9, 
@@ -229,7 +231,7 @@ class HDFEyeOperator(Operator):
                         sac_dict[sac_dict['eye'] == eye]
                         eso = EyeSignalOperator(input_object=eye_dict, eyelink_blink_data=blink_dict, eyelink_sac_data=sac_dict, sample_rate=sample_rate,)
                     else:
-                        eso = EyeSignalOperator(input_object=eye_dict,sample_rate=sample_rate)
+                        eso = EyeSignalOperator(input_object=eye_dict, sample_rate=sample_rate)
     
                     # interpolate blinks:
                     eso.interpolate_blinks(method='linear')
@@ -244,7 +246,7 @@ class HDFEyeOperator(Operator):
                     
                     # regress blink and saccade responses
                     # try:
-                    eso.regress_blinks()
+                    eso.regress_blinks(regress_blinks=regress_blinks, regress_sacs=regress_blinks)
                     # except:
                     #     eso.lp_filt_pupil_clean = eso.lp_filt_pupil.copy()
                     #     eso.bp_filt_pupil_clean = eso.bp_filt_pupil.copy()

--- a/src/HDFEyeOperator.py
+++ b/src/HDFEyeOperator.py
@@ -285,8 +285,8 @@ class HDFEyeOperator(Operator):
                     
                     # save summary plot:
                     fig = eso.summary_plot()
-                    fig.savefig(os.path.join(os.path.split(self.input_object)[0], 'pupil_preprocess_detection_{}_{}_{}.pdf'.format(alias, i, eye)))
-
+                    fig.savefig(os.path.join(os.path.split(self.input_object)[0], 'preprocess_{}_{}_{}.pdf'.format(alias, i, eye)))
+                    
                     # try time-frequency decomposition of the baseline signal
                     try:
                         eso.time_frequency_decomposition_pupil(

--- a/src/HDFEyeOperator.py
+++ b/src/HDFEyeOperator.py
@@ -158,6 +158,7 @@ class HDFEyeOperator(Operator):
             normalization = 'psc',
             regress_blinks = True,
             regress_sacs = True,
+            regress_xy = False, 
             use_standard_blinksac_kernels = True,
             minimal_frequency_filterbank = 0.0025, 
             maximal_frequency_filterbank = 0.1, 
@@ -247,7 +248,7 @@ class HDFEyeOperator(Operator):
                     
                     # regress blink and saccade responses
                     # try:
-                    eso.regress_blinks(regress_blinks=regress_blinks, regress_sacs=regress_blinks, use_standard_blinksac_kernels=use_standard_blinksac_kernels)
+                    eso.regress_blinks(regress_blinks=regress_blinks, regress_sacs=regress_sacs, regress_xy=regress_xy, use_standard_blinksac_kernels=use_standard_blinksac_kernels)
                     # except:
                     #     eso.lp_filt_pupil_clean = eso.lp_filt_pupil.copy()
                     #     eso.bp_filt_pupil_clean = eso.bp_filt_pupil.copy()

--- a/src/HDFEyeOperator.py
+++ b/src/HDFEyeOperator.py
@@ -158,6 +158,7 @@ class HDFEyeOperator(Operator):
             normalization = 'psc',
             regress_blinks = True,
             regress_sacs = True,
+            use_standard_blinksac_kernels = True,
             minimal_frequency_filterbank = 0.0025, 
             maximal_frequency_filterbank = 0.1, 
             nr_freq_bins_filterbank = 9, 
@@ -246,7 +247,7 @@ class HDFEyeOperator(Operator):
                     
                     # regress blink and saccade responses
                     # try:
-                    eso.regress_blinks(regress_blinks=regress_blinks, regress_sacs=regress_blinks)
+                    eso.regress_blinks(regress_blinks=regress_blinks, regress_sacs=regress_blinks, use_standard_blinksac_kernels=use_standard_blinksac_kernels)
                     # except:
                     #     eso.lp_filt_pupil_clean = eso.lp_filt_pupil.copy()
                     #     eso.bp_filt_pupil_clean = eso.bp_filt_pupil.copy()

--- a/src/HDFEyeOperator.py
+++ b/src/HDFEyeOperator.py
@@ -18,453 +18,449 @@ from EyeSignalOperator import EyeSignalOperator, detect_saccade_from_data
 from IPython import embed as shell 
 
 class HDFEyeOperator(Operator):
-	"""
-	HDFEyeOperator is typically used to deal with the data from 
-	an entire session. In that case it is associated with a single
-	hdf5 file that contains all eye data for the runs of that session,
-	and which is given as input_object upon the creation of the
-	HDFEyeOperator object 
-	"""
-	
-	def __init__(self, input_object, **kwargs):
-		super(HDFEyeOperator, self).__init__(input_object = input_object, **kwargs)
-		"""input_object is the name of the hdf5 file that this operator will create"""
-	
-	def add_edf_file(self, edf_file_name):
-		"""
-		add_edf_file is the first step in adding a run's edf data 
-		to the sessions hdf5 file indicated by self.input_object
-		
-		add_edf_file creates an EDFOperator object using edf_file_name, and thereby
-		immediately converts the edf file to two asc files.
-		add_edf_file then uses the EDFOperator object to read all kinds
-		of event information (trials, keys, etc) from the event asc file into
-		internal variables of the EDFOperator object,
-		and also reads the sample data per block (i.e. interval between startrecording
-		and stoprecording) into a separate internal variable of the EDFOperator object.
-		Putting these data into a hdf5 file is not done here, but in 
-		self.edf_message_data_to_hdf and self.edf_gaze_data_to_hdf
-		"""
-		
-		self.edf_operator = EDFOperator(edf_file_name)
-		# now create all messages
-		self.edf_operator.read_all_messages()
-		
-		# set up blocks for the floating-point data
-		self.edf_operator.take_gaze_data_for_blocks()
-	
-	def open_hdf_file(self, mode = "a"):
-		"""
-		open_hdf_file opens the hdf file that was indicated when
-		first creating this HDFEyeOperator object
-		"""
-		self.h5f = open_file(self.input_object, mode = mode )
-	
-	def close_hdf_file(self):
-		"""
-		close_hdf_file closes the hdf file that was indicated when
-		first creating this HDFEyeOperator object
-		"""
-		self.h5f.close()
-	
-	def add_table_to_hdf(self, run_group, type_dict, data, name = 'bla',filename = []):
-		"""
-		add_table_to_hdf adds a data table to the hdf file
-		"""
-		if filename == []:
-			filename = self.edf_operator.input_file_name
-			
-		this_table = self.h5f.create_table(run_group, name, type_dict, '%s in file %s' % (name, self.edf_operator.input_file_name))
-		
-		row = this_table.row
-		for r in data:
-			for par in r.keys():
-				row[par] = r[par]
-			row.append()
-		this_table.flush()
-	
-	def edf_message_data_to_hdf(self, alias = None, mode = 'a'):
-		"""
-		edf_message_data_to_hdf writes the message data
-		from the run's edf file to the session's hdf5 file
-		indicated by self.input_object.
-		
-		The data have typically been taken from the edf
-		file and associated with self.edf_operator during an
-		earlier call to self.add_edf_file(), but if this is not the case,
-		and there is no self.edf_operator,
-		then self.add_edf_file() can be called right here.
-		
-		within the hdf5 file, data are stored under, and can later be retrieved
-		at /[source_edf_file_name_without_extension]/[data_kind_name],
-		with the latter being e.g. 'trials'
-		"""
-		if not hasattr(self, 'edf_operator'):
-			self.add_edf_file(edf_file_name = alias)
-		
-		if alias == None:
-			alias = os.path.split(self.edf_operator.input_file_name)[-1]
-		self.open_hdf_file( mode = mode )
-		self.logger.info('Adding message data from %s to group  %s to %s' % (os.path.split(self.edf_operator.input_file_name)[-1], alias, self.input_object))
-		thisRunGroup = self.h5f.create_group("/", alias, 'Run ' + alias +' imported from ' + self.edf_operator.input_file_name)
-		
-		#
-		#	trials and trial phases
-		#
-		
-		if hasattr(self.edf_operator, 'trials'):
-			# create a table for the parameters of this run's trials
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.trial_type_dictionary, self.edf_operator.trials, 'trials')
-		
-		if hasattr(self.edf_operator, 'trial_phases'):
-			# create a table for the parameters of this run's trials
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.trial_phase_type_dictionary, self.edf_operator.trial_phases, 'trial_phases')
-		
-		#
-		#	supporting data types
-		#
-		
-		if hasattr(self.edf_operator, 'parameters'):
-			# create a table for the parameters of this run's trials
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.parameter_type_dictionary, self.edf_operator.parameters, 'parameters')
-		
-		if hasattr(self.edf_operator, 'events'):
-			# create a table for the events of this run's trials
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.event_type_dictionary, self.edf_operator.events, 'events')
-		
-		if hasattr(self.edf_operator, 'sounds'):
-			# create a table for the events of this run's trials
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.sound_type_dictionary, self.edf_operator.sounds, 'sounds')
-		
-		#
-		#	eyelink data types
-		#
-		
-		if hasattr(self.edf_operator, 'saccades_from_message_file'):
-			# create a table for the saccades from the eyelink of this run's trials
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.saccade_type_dictionary, self.edf_operator.saccades_from_message_file, 'saccades_from_message_file')
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.blink_type_dictionary, self.edf_operator.blinks_from_message_file, 'blinks_from_message_file')
-			self.add_table_to_hdf(thisRunGroup, self.edf_operator.fixation_type_dictionary, self.edf_operator.fixations_from_message_file, 'fixations_from_message_file')
-		
-		# first close the hdf5 file to write to it with pandas
-		self.close_hdf_file()
-	
-	def edf_gaze_data_to_hdf(self, 
-			alias = None, 
-			which_eye = 0, 
-			pupil_hp = 0.01, 
-			pupil_lp = 6,
-			sample_rate = 1000.,
-			minimal_frequency_filterbank = 0.0025, 
-			maximal_frequency_filterbank = 0.1, 
-			nr_freq_bins_filterbank = 9, 
-			n_cycles_filterbank = 1, 
-			cycle_buffer_filterbank = 3,
-			tf_decomposition_filterbank ='lp_butterworth' 
-			):
-		"""
-		edf_gaze_data_to_hdf takes the gaze data
-		that is in the run's edf file, processes it,
-		and writes the results, as well as the raw data,
-		to the sessions hdf5 file that is indicated by
-		self.input_object, and also produces some visual
-		feedback in the form of figures.
-		
-		The data have typically been taken from the edf
-		file and associated with self.edf_operator during an
-		earlier call to self.add_edf_file(), but if this is not the case,
-		and there is no self.edf_operator,
-		then self.add_edf_file() can be called right here.
-		
-		within the hdf5 file, data are stored under, and can later be retrieved
-		at /[source_edf_file_name_without_extension]/[block_name],
-		with the latter being e.g. 'block_1'
-		
-		edf_gaze_data_to_hdf also produces plots of the raw pupil data and
-		blink-interpolated data (stored in pdf files named 'blink_interpolation_1_'[...])
-		and of something akin to the derivative of the pupil data along with
-		markers indicating that variable's peaks (stored in pdf files named 'blink_interpolation_2_'[...])
-		"""
-		
-		# shell()
-		
-		if not hasattr(self, 'edf_operator'):
-			self.add_edf_file(edf_file_name = alias)
-		
-		if alias == None:
-			alias = os.path.split(self.edf_operator.input_file_name)[-1]
-		self.logger.info('Adding gaze data from %s to group  %s to %s' % (os.path.split(self.edf_operator.input_file_name)[-1], alias, self.input_object))
-		
-		#
-		#	gaze data in blocks
-		#
-		with pd.get_store(self.input_object) as h5_file:
-			# shell()
-			# recreate the non-gaze data for the block, that is, its sampling rate, eye of origin etc.
-			blocks_data_frame = pd.DataFrame([dict([[i,self.edf_operator.blocks[j][i]] for i in self.edf_operator.blocks[0].keys() if i not in ('block_data', 'data_columns')]) for j in range(len(self.edf_operator.blocks))])
-			h5_file.put("/%s/blocks"%alias, blocks_data_frame)
-			
-			# gaze data per block
-			if not 'block_data' in self.edf_operator.blocks[0].keys():
-				self.edf_operator.take_gaze_data_for_blocks()
-			for i, block in enumerate(self.edf_operator.blocks):
-				bdf = pd.DataFrame(block['block_data'], columns = block['data_columns'])
-			
-				#
-				# preprocess pupil:
-				#
-				for eye in blocks_data_frame.eye_recorded[i]: # this is a string with one or two letters, 'L', 'R' or 'LR'
-				# create dictionary of data per block:
-					gazeX = bdf[eye+'_gaze_x']
-					gazeY = bdf[eye+'_gaze_y']
-					pupil = bdf[eye+'_pupil']
-					eye_dict = {'timepoints':bdf.time, 'gaze_X':gazeX, 'gaze_Y':gazeY, 'pupil':pupil,}
-					
-					# create instance of class EyeSignalOperator, and include the blink data as detected by the Eyelink 1000:
-					if hasattr(self.edf_operator, 'blinks_from_message_file'):
-						blink_dict = self.read_session_data(alias, 'blinks_from_message_file')
-						blink_dict[blink_dict['eye'] == eye]
-						sac_dict = self.read_session_data(alias, 'saccades_from_message_file')
-						sac_dict[sac_dict['eye'] == eye]
-						eso = EyeSignalOperator(input_object=eye_dict, eyelink_blink_data=blink_dict,sample_rate=sample_rate, eyelink_sac_data = sac_dict)
-					else:
-						eso = EyeSignalOperator(input_object=eye_dict,sample_rate=sample_rate)
-	
-					# interpolate blinks:
-					eso.interpolate_blinks(method='linear')
-					eso.interpolate_blinks2()
+    """
+    HDFEyeOperator is typically used to deal with the data from 
+    an entire session. In that case it is associated with a single
+    hdf5 file that contains all eye data for the runs of that session,
+    and which is given as input_object upon the creation of the
+    HDFEyeOperator object 
+    """
+    
+    def __init__(self, input_object, **kwargs):
+        super(HDFEyeOperator, self).__init__(input_object = input_object, **kwargs)
+        """input_object is the name of the hdf5 file that this operator will create"""
+    
+    def add_edf_file(self, edf_file_name):
+        """
+        add_edf_file is the first step in adding a run's edf data 
+        to the sessions hdf5 file indicated by self.input_object
+        
+        add_edf_file creates an EDFOperator object using edf_file_name, and thereby
+        immediately converts the edf file to two asc files.
+        add_edf_file then uses the EDFOperator object to read all kinds
+        of event information (trials, keys, etc) from the event asc file into
+        internal variables of the EDFOperator object,
+        and also reads the sample data per block (i.e. interval between startrecording
+        and stoprecording) into a separate internal variable of the EDFOperator object.
+        Putting these data into a hdf5 file is not done here, but in 
+        self.edf_message_data_to_hdf and self.edf_gaze_data_to_hdf
+        """
+        
+        self.edf_operator = EDFOperator(edf_file_name)
+        # now create all messages
+        self.edf_operator.read_all_messages()
+        
+        # set up blocks for the floating-point data
+        self.edf_operator.take_gaze_data_for_blocks()
+    
+    def open_hdf_file(self, mode = "a"):
+        """
+        open_hdf_file opens the hdf file that was indicated when
+        first creating this HDFEyeOperator object
+        """
+        self.h5f = open_file(self.input_object, mode = mode )
+    
+    def close_hdf_file(self):
+        """
+        close_hdf_file closes the hdf file that was indicated when
+        first creating this HDFEyeOperator object
+        """
+        self.h5f.close()
+    
+    def add_table_to_hdf(self, run_group, type_dict, data, name = 'bla',filename = []):
+        """
+        add_table_to_hdf adds a data table to the hdf file
+        """
+        if filename == []:
+            filename = self.edf_operator.input_file_name
+            
+        this_table = self.h5f.create_table(run_group, name, type_dict, '%s in file %s' % (name, self.edf_operator.input_file_name))
+        
+        row = this_table.row
+        for r in data:
+            for par in r.keys():
+                row[par] = r[par]
+            row.append()
+        this_table.flush()
+    
+    def edf_message_data_to_hdf(self, alias = None, mode = 'a'):
+        """
+        edf_message_data_to_hdf writes the message data
+        from the run's edf file to the session's hdf5 file
+        indicated by self.input_object.
+        
+        The data have typically been taken from the edf
+        file and associated with self.edf_operator during an
+        earlier call to self.add_edf_file(), but if this is not the case,
+        and there is no self.edf_operator,
+        then self.add_edf_file() can be called right here.
+        
+        within the hdf5 file, data are stored under, and can later be retrieved
+        at /[source_edf_file_name_without_extension]/[data_kind_name],
+        with the latter being e.g. 'trials'
+        """
+        if not hasattr(self, 'edf_operator'):
+            self.add_edf_file(edf_file_name = alias)
+        
+        if alias == None:
+            alias = os.path.split(self.edf_operator.input_file_name)[-1]
+        self.open_hdf_file( mode = mode )
+        self.logger.info('Adding message data from %s to group  %s to %s' % (os.path.split(self.edf_operator.input_file_name)[-1], alias, self.input_object))
+        thisRunGroup = self.h5f.create_group("/", alias, 'Run ' + alias +' imported from ' + self.edf_operator.input_file_name)
+        
+        #
+        #    trials and trial phases
+        #
+        
+        if hasattr(self.edf_operator, 'trials'):
+            # create a table for the parameters of this run's trials
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.trial_type_dictionary, self.edf_operator.trials, 'trials')
+        
+        if hasattr(self.edf_operator, 'trial_phases'):
+            # create a table for the parameters of this run's trials
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.trial_phase_type_dictionary, self.edf_operator.trial_phases, 'trial_phases')
+        
+        #
+        #    supporting data types
+        #
+        
+        if hasattr(self.edf_operator, 'parameters'):
+            # create a table for the parameters of this run's trials
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.parameter_type_dictionary, self.edf_operator.parameters, 'parameters')
+        
+        if hasattr(self.edf_operator, 'events'):
+            # create a table for the events of this run's trials
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.event_type_dictionary, self.edf_operator.events, 'events')
+        
+        if hasattr(self.edf_operator, 'sounds'):
+            # create a table for the events of this run's trials
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.sound_type_dictionary, self.edf_operator.sounds, 'sounds')
+        
+        #
+        #    eyelink data types
+        #
+        
+        if hasattr(self.edf_operator, 'saccades_from_message_file'):
+            # create a table for the saccades from the eyelink of this run's trials
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.saccade_type_dictionary, self.edf_operator.saccades_from_message_file, 'saccades_from_message_file')
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.blink_type_dictionary, self.edf_operator.blinks_from_message_file, 'blinks_from_message_file')
+            self.add_table_to_hdf(thisRunGroup, self.edf_operator.fixation_type_dictionary, self.edf_operator.fixations_from_message_file, 'fixations_from_message_file')
+        
+        # first close the hdf5 file to write to it with pandas
+        self.close_hdf_file()
+    
+    def edf_gaze_data_to_hdf(self, 
+            alias = None, 
+            which_eye = 0, 
+            pupil_hp = 0.01, 
+            pupil_lp = 6,
+            sample_rate = 1000.,
+            minimal_frequency_filterbank = 0.0025, 
+            maximal_frequency_filterbank = 0.1, 
+            nr_freq_bins_filterbank = 9, 
+            n_cycles_filterbank = 1, 
+            cycle_buffer_filterbank = 3,
+            tf_decomposition_filterbank ='lp_butterworth' 
+            ):
+        """
+        edf_gaze_data_to_hdf takes the gaze data
+        that is in the run's edf file, processes it,
+        and writes the results, as well as the raw data,
+        to the sessions hdf5 file that is indicated by
+        self.input_object, and also produces some visual
+        feedback in the form of figures.
+        
+        The data have typically been taken from the edf
+        file and associated with self.edf_operator during an
+        earlier call to self.add_edf_file(), but if this is not the case,
+        and there is no self.edf_operator,
+        then self.add_edf_file() can be called right here.
+        
+        within the hdf5 file, data are stored under, and can later be retrieved
+        at /[source_edf_file_name_without_extension]/[block_name],
+        with the latter being e.g. 'block_1'
+        
+        edf_gaze_data_to_hdf also produces plots of the raw pupil data and
+        blink-interpolated data (stored in pdf files named 'blink_interpolation_1_'[...])
+        and of something akin to the derivative of the pupil data along with
+        markers indicating that variable's peaks (stored in pdf files named 'blink_interpolation_2_'[...])
+        """
+        
+        # shell()
+        
+        if not hasattr(self, 'edf_operator'):
+            self.add_edf_file(edf_file_name = alias)
+        
+        if alias == None:
+            alias = os.path.split(self.edf_operator.input_file_name)[-1]
+        self.logger.info('Adding gaze data from %s to group  %s to %s' % (os.path.split(self.edf_operator.input_file_name)[-1], alias, self.input_object))
+        
+        #
+        #    gaze data in blocks
+        #
+        with pd.get_store(self.input_object) as h5_file:
+            # shell()
+            # recreate the non-gaze data for the block, that is, its sampling rate, eye of origin etc.
+            blocks_data_frame = pd.DataFrame([dict([[i,self.edf_operator.blocks[j][i]] for i in self.edf_operator.blocks[0].keys() if i not in ('block_data', 'data_columns')]) for j in range(len(self.edf_operator.blocks))])
+            h5_file.put("/%s/blocks"%alias, blocks_data_frame)
+            
+            # gaze data per block
+            if not 'block_data' in self.edf_operator.blocks[0].keys():
+                self.edf_operator.take_gaze_data_for_blocks()
+            for i, block in enumerate(self.edf_operator.blocks):
+                bdf = pd.DataFrame(block['block_data'], columns = block['data_columns'])
+            
+                #
+                # preprocess pupil:
+                #
+                for eye in blocks_data_frame.eye_recorded[i]: # this is a string with one or two letters, 'L', 'R' or 'LR'
+                # create dictionary of data per block:
+                    gazeX = bdf[eye+'_gaze_x']
+                    gazeY = bdf[eye+'_gaze_y']
+                    pupil = bdf[eye+'_pupil']
+                    eye_dict = {'timepoints':bdf.time, 'gaze_X':gazeX, 'gaze_Y':gazeY, 'pupil':pupil,}
+                    
+                    # create instance of class EyeSignalOperator, and include the blink data as detected by the Eyelink 1000:
+                    if hasattr(self.edf_operator, 'blinks_from_message_file'):
+                        blink_dict = self.read_session_data(alias, 'blinks_from_message_file')
+                        blink_dict[blink_dict['eye'] == eye]
+                        sac_dict = self.read_session_data(alias, 'saccades_from_message_file')
+                        sac_dict[sac_dict['eye'] == eye]
+                        eso = EyeSignalOperator(input_object=eye_dict, eyelink_blink_data=blink_dict, eyelink_sac_data=sac_dict, sample_rate=sample_rate,)
+                    else:
+                        eso = EyeSignalOperator(input_object=eye_dict,sample_rate=sample_rate)
+    
+                    # interpolate blinks:
+                    eso.interpolate_blinks(method='linear')
+                    eso.interpolate_blinks2()
 
-					# low-pass and band-pass pupil data:
-					eso.filter_pupil(hp=pupil_hp, lp=pupil_lp)
+                    # low-pass and band-pass pupil data:
+                    eso.filter_pupil(hp=pupil_hp, lp=pupil_lp)
+                    
+                    # now dt the resulting pupil data:
+                    eso.dt_pupil(dtype='lp_filt_pupil')
+                    eso.dt_pupil(dtype='bp_filt_pupil')
+                    
+                    # regress blink and saccade responses
+                    try:
+                        eso.regress_blinks()
+                    except:
+                        eso.lp_filt_pupil_clean = eso.lp_filt_pupil.copy()
+                        eso.bp_filt_pupil_clean = eso.bp_filt_pupil.copy()
 
-					# regress blink and saccade responses
-					eso.regress_blinks()
+                    # zscore filtered pupil data:
+                    eso.zscore_pupil(dtype='lp_filt_pupil')
+                    eso.zscore_pupil(dtype='lp_filt_pupil_clean')
+                    eso.zscore_pupil(dtype='bp_filt_pupil')
+                    eso.zscore_pupil(dtype='bp_filt_pupil_clean')
+                    # percent signal change filtered pupil data:
+                    eso.percent_signal_change_pupil(dtype='lp_filt_pupil')
+                    eso.percent_signal_change_pupil(dtype='lp_filt_pupil_clean')
+                    eso.percent_signal_change_pupil(dtype='bp_filt_pupil')
+                    eso.percent_signal_change_pupil(dtype='bp_filt_pupil_clean')
+                    
+                    # add to existing dataframe:
+                    bdf[eye+'_interpolated_timepoints'] = eso.interpolated_time_points
+                    bdf[eye+'_pupil_int'] = eso.interpolated_pupil
+                    bdf[eye+'_pupil_hp'] = eso.hp_filt_pupil
+                    bdf[eye+'_pupil_baseline'] = eso.baseline_filt_pupil
+                    bdf[eye+'_gaze_x_int'] = eso.interpolated_x
+                    bdf[eye+'_gaze_y_int'] = eso.interpolated_y
+                    
+                    bdf[eye+'_pupil_lp'] = eso.lp_filt_pupil
+                    bdf[eye+'_pupil_lp_dt'] = eso.lp_filt_pupil_dt
+                    bdf[eye+'_pupil_lp_zscore'] = eso.lp_filt_pupil_zscore
+                    bdf[eye+'_pupil_lp_psc'] = eso.lp_filt_pupil_psc
+                    bdf[eye+'_pupil_lp_clean'] = eso.lp_filt_pupil_clean
+                    bdf[eye+'_pupil_lp_clean_zscore'] = eso.lp_filt_pupil_clean_zscore
+                    bdf[eye+'_pupil_lp_clean_psc'] = eso.lp_filt_pupil_clean_psc
+                    
+                    bdf[eye+'_pupil_bp'] = eso.bp_filt_pupil
+                    bdf[eye+'_pupil_bp_dt'] = eso.bp_filt_pupil_dt
+                    bdf[eye+'_pupil_bp_zscore'] = eso.bp_filt_pupil_zscore
+                    bdf[eye+'_pupil_bp_psc'] = eso.bp_filt_pupil_psc
+                    bdf[eye+'_pupil_bp_clean'] = eso.bp_filt_pupil_clean
+                    bdf[eye+'_pupil_bp_clean_zscore'] = eso.bp_filt_pupil_clean_zscore
+                    bdf[eye+'_pupil_bp_clean_psc'] = eso.bp_filt_pupil_clean_psc
+                    
+                    # save summary plot:
+                    fig = eso.summary_plot()
+                    fig.savefig(os.path.join(os.path.split(self.input_object)[0], 'pupil_preprocess_detection_{}_{}_{}.pdf'.format(alias, i, eye)))
 
-					for dt in ['lp_filt_pupil','lp_filt_pupil_clean','bp_filt_pupil','bp_filt_pupil_clean']:
-						# percent signal change filtered pupil data:
-						eso.percent_signal_change_pupil(dtype=dt)
-						eso.zscore_pupil(dtype=dt)
-						eso.dt_pupil(dtype=dt)
-					
-					# add to existing dataframe:
-					bdf[eye+'_pupil_int'] = eso.interpolated_pupil
-					bdf[eye+'_pupil_hp'] = eso.hp_filt_pupil
-					bdf[eye+'_pupil_lp'] = eso.lp_filt_pupil
+                    # try time-frequency decomposition of the baseline signal
+                    try:
+                        eso.time_frequency_decomposition_pupil(
+                                minimal_frequency = minimal_frequency_filterbank, 
+                                maximal_frequency = maximal_frequency_filterbank, 
+                                nr_freq_bins = nr_freq_bins_filterbank, 
+                                n_cycles = n_cycles_filterbank, 
+                                cycle_buffer = cycle_buffer_filterbank,
+                                tf_decomposition=tf_decomposition_filterbank,
+                                )
+                        self.logger.info('Performed T-F analysis of type %s'%tf_decomposition_filterbank)
+                        for freq in eso.band_pass_filter_bank_pupil.keys():
+                            bdf[eye+'_pupil_filterbank_bp_%2.5f'%freq] = eso.band_pass_filter_bank_pupil[freq]
+                            self.logger.info('Saved T-F analysis %2.5f'%freq)
+                    except:
+                        self.logger.error('Something went wrong with T-F analysis of type %s'%tf_decomposition_filterbank)
+                        pass
+                    
+                # put in HDF5:
+                h5_file.put("/%s/block_%i"%(alias, i), bdf)
+    
+    def data_frame_to_hdf(self, alias, name, data_frame):
+        """docstring for data_frame_to_hdf"""
+        with pd.get_store(self.input_object) as h5_file:
+            h5_file.put("/%s/%s"%(alias, name), data_frame)
+    
+    #
+    #    we also have to get the data from the hdf5 file. 
+    #    first, based on simply a EL timestamp period
+    #
+    
+    def sample_in_block(self, sample, block_table):
+        """docstring for sample_in_block"""
+        return np.arange(block_table['block_end_timestamp'].shape[0])[np.array(block_table['block_end_timestamp'] > float(sample), dtype=bool)][0]
+    
+    def data_from_time_period(self, time_period, alias, columns = None):
+        """data_from_time_period delivers a set of data of type data_type for a given timeperiod"""
+        # find the block in which the data resides, based on just the first time of time_period
+        with pd.get_store(self.input_object) as h5_file:
+            period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias]) 
+            table = h5_file['%s/block_%i'%(alias, period_block_nr)]
+            if columns == None:
+                columns = table.keys()
+        if 'L_vel' in columns:
+            columns = table.keys()
+        return table[(table['time'] > float(time_period[0])) & (table['time'] < float(time_period[1]))][columns]
+    
+    def eye_during_period(self, time_period, alias):
+        """eye_during_period returns the identity of the eye that was recorded during a given period"""
+        with pd.get_store(self.input_object) as h5_file:
+            period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias])
+            eye = h5_file['%s/blocks'%alias]['eye_recorded'][period_block_nr]
+        return eye
+    
+    def eye_during_trial(self, trial_nr, alias):
+        """docstring for signal_from_trial"""
+        with pd.get_store(self.input_object) as h5_file:
+            table = h5_file['%s/trials'%alias]
+            time_period = np.array(table[table['trial_start_index'] == trial_nr][['trial_start_EL_timestamp', 'trial_end_EL_timestamp']])
+        return self.eye_during_period(time_period[0], alias)
 
-					bdf[eye+'_pupil_lp_psc'] = eso.lp_filt_pupil_psc
-					bdf[eye+'_pupil_lp_diff'] = np.concatenate((np.array([0]),np.diff(eso.lp_filt_pupil)))
-					bdf[eye+'_pupil_bp'] = eso.bp_filt_pupil
-					bdf[eye+'_pupil_bp_dt'] = eso.bp_filt_pupil_dt
-					bdf[eye+'_pupil_bp_zscore'] = eso.bp_filt_pupil_zscore
-					bdf[eye+'_pupil_bp_psc'] = eso.bp_filt_pupil_psc
-					bdf[eye+'_pupil_baseline'] = eso.baseline_filt_pupil
+    def screen_dimensions_during_period(self, time_period, alias):
+        """docstring for eye_during_period"""
+        with pd.get_store(self.input_object) as h5_file:
+            period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias])
+            return np.array(h5_file['%s/blocks'%alias][['screen_x_pix','screen_y_pix']][period_block_nr:period_block_nr+1]).squeeze()
 
-					bdf[eye+'_gaze_x_int'] = eso.interpolated_x
-					bdf[eye+'_gaze_y_int'] = eso.interpolated_y
+    def screen_dimensions_during_trial(self, trial_nr, alias):
+        """docstring for eye_during_period"""
+        with pd.get_store(self.input_object) as h5_file:
+            table = h5_file['%s/trials'%alias]
+            time_period = np.array(table[table['trial_start_index'] == trial_nr][['trial_start_EL_timestamp', 'trial_end_EL_timestamp']])[0]
+        return self.screen_dimensions_during_period(time_period = time_period, alias = alias)    
+    
+    def sample_rate_during_period(self, time_period, alias):
+        """docstring for eye_during_period"""
+        with pd.get_store(self.input_object) as h5_file:
+            period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias])
+            return h5_file['%s/blocks'%alias]['sample_rate'][period_block_nr]
+    
+    def sample_rate_during_trial(self, trial_nr, alias):
+        """docstring for signal_from_trial"""
+        with pd.get_store(self.input_object) as h5_file:
+            table = h5_file['%s/trials'%alias]
+            time_period = np.array(table[table['trial_start_index'] == trial_nr][['trial_start_EL_timestamp', 'trial_end_EL_timestamp']])
+        return float(self.sample_rate_during_period(time_period[0], alias))
+    
+    def signal_during_period(self, time_period, alias, signal, requested_eye = 'L'):
+        """docstring for gaze_during_period"""
+        recorded_eye = self.eye_during_period(time_period, alias)
+        if requested_eye == 'LR' and recorded_eye == 'LR':
+            if np.any([signal == 'gaze', signal == 'vel']):
+                columns = [s%signal for s in ['L_%s_x', 'L_%s_y', 'R_%s_x', 'R_%s_y']]
+            elif signal == 'time':
+                columns = [s%signal for s in ['%s']]        
+            else:
+                columns = [s%signal for s in ['L_%s', 'R_%s']]
+        elif requested_eye in recorded_eye:
+            if np.any([signal == 'gaze', signal == 'vel']):
+                columns = [s%signal for s in [requested_eye + '_%s_x', requested_eye + '_%s_y']]
+            elif signal == 'time':
+                columns = [s%signal for s in ['%s']]
+            else:
+                columns = [s%signal for s in [requested_eye + '_%s']]
+        else:
+            with pd.get_store(self.input_object) as h5_file:
+                self.logger.error('requested eye %s not found in block %i' % (requested_eye, self.sample_in_block(time_period[0], block_table = h5_file['%s/blocks'%alias])))
+            return None    # assert something, dammit!
+        return self.data_from_time_period(time_period, alias, columns)
+    
+    def saccades_during_period(self, time_period, alias, requested_eye = 'L', l = 5):
+        xy_data = self.signal_during_period(time_period = time_period, alias = alias, signal = 'gaze', requested_eye = requested_eye)
+        vel_data = self.signal_during_period(time_period = time_period, alias = alias, signal = 'vel', requested_eye = requested_eye) 
+        return detect_saccade_from_data(xy_data = xy_data, vel_data = vel_data, l = l, sample_rate = self.sample_rate_during_period(time_period, alias))
 
-					# blink/saccade regressed versions
-					bdf[eye+'_pupil_lp_clean'] = eso.lp_filt_pupil_clean
-					bdf[eye+'_pupil_lp_clean_psc'] = eso.lp_filt_pupil_clean_psc
-					bdf[eye+'_pupil_lp_clean_zscore'] = eso.lp_filt_pupil_clean_zscore
+    #
+    #    second, based also on trials, using the above functionality
+    #
+    
+    def signal_from_trial(self, trial_nr, alias, signal, requested_eye = 'L', time_extensions = [0,0]):
+        """docstring for signal_from_trial"""
+        with pd.get_store(self.input_object) as h5_file:
+            table = h5_file['%s/trials'%alias]
+            time_period = np.array([
+                table[table['trial_start_index'] == trial_nr]['trial_start_EL_timestamp'] + time_extensions[0],
+                table[table['trial_start_index'] == trial_nr]['trial_end_EL_timestamp'] + time_extensions[1]
+            ]).squeeze()
+        return self.signal_during_period(time_period, alias, signal, requested_eye = requested_eye)
+    
+    def time_period_for_trial_phases(self, trial_nr, trial_phases, alias ):
+        """the time period corresponding to the trial phases requested.
+        """
+        with pd.get_store(self.input_object) as h5_file:
+            table = h5_file['%s/trial_phases'%alias]
+            # check whether one of the trial phases is the end or the beginning of the trial.
+            # if so, then supplant the time of that phase with its trial's end or start time.
+            if trial_phases[0] == 0:
+                start_time = table[table['trial_start_index'] == trial_nr]['trial_start_EL_timestamp']
+            else:
+                start_time = table[((table['trial_phase_index'] == trial_phases[0]) * (table['trial_phase_trial'] == trial_nr))]['trial_phase_EL_timestamp']
+            if trial_phases[-1] == -1:
+                end_time = table[table['trial_start_index'] == trial_nr]['trial_end_EL_timestamp']
+            else:
+                end_time = table[((table['trial_phase_index'] == trial_phases[1]) * (table['trial_phase_trial'] == trial_nr))]['trial_phase_EL_timestamp']
+            time_period = np.array([np.array(start_time), np.array(end_time)]).squeeze()
+        return time_period
 
-					bdf[eye+'_pupil_bp_clean'] = eso.bp_filt_pupil_clean
-					bdf[eye+'_pupil_bp_clean_psc'] = eso.bp_filt_pupil_clean_psc
-					bdf[eye+'_pupil_bp_clean_zscore'] = eso.bp_filt_pupil_clean_zscore
-					bdf[eye+'_pupil_bp_clean_dt'] = eso.bp_filt_pupil_clean_dt
-				
-					# plot interpolated pupil time series:
-					fig = pl.figure(figsize = (16, 2.5))
-					x = np.linspace(0,eso.raw_pupil.shape[0]/sample_rate, eso.raw_pupil.shape[0])
-					pl.plot(x, eso.raw_pupil, 'b', rasterized=True)
-					pl.plot(x, eso.interpolated_pupil, 'g', rasterized=True)
-					pl.ylabel('pupil size (raw)')
-					pl.xlabel('time (s)')
-					pl.legend(['raw', 'int + filt'])
-					fig.savefig(os.path.join(os.path.split(self.input_object)[0], 'blink_interpolation_1_{}_{}_{}.pdf'.format(alias, i, eye)))
-					
-					# plot results blink detection next to hdf5:
-					fig = pl.figure(figsize = (16, 2.5))
-					pl.plot(eso.pupil_diff, rasterized=True)
-					pl.plot(eso.peaks, eso.pupil_diff[eso.peaks], '+', mec='r', mew=2, ms=8, rasterized=True)
-					pl.ylim(ymin=-200, ymax=200)
-					pl.ylabel('diff pupil size (raw)')
-					pl.xlabel('samples')
-					fig.savefig(os.path.join(os.path.split(self.input_object)[0], 'blink_interpolation_2_{}_{}_{}.pdf'.format(alias, i, eye)))
+    def signal_from_trial_phases(self, trial_nr, trial_phases, alias, signal, requested_eye = 'L', time_extensions = [0,0]):
+        """docstring for signal_from_trial"""
+        time_period = self.time_period_for_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias)
+        time_period = np.array([time_period[0] + time_extensions[0], time_period[1] + time_extensions[1]]).squeeze()
+        return self.signal_during_period(time_period, alias, signal, requested_eye = requested_eye)
+    
+    def saccades_from_trial_phases(self, trial_nr, trial_phases, alias, requested_eye = 'L', time_extensions = [0,0], l = 5):
+        time_period = self.time_period_for_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias)
+        time_period = np.array([time_period[0] + time_extensions[0], time_period[1] + time_extensions[1]]).squeeze()
+        return self.saccades_during_period(time_period = time_period, alias = alias, requested_eye = requested_eye, time_extensions = time_extensions, l = l)
 
-					# try time-frequency decomposition of the baseline signal
-					try:
-						eso.time_frequency_decomposition_pupil(
-								minimal_frequency = minimal_frequency_filterbank, 
-								maximal_frequency = maximal_frequency_filterbank, 
-								nr_freq_bins = nr_freq_bins_filterbank, 
-								n_cycles = n_cycles_filterbank, 
-								cycle_buffer = cycle_buffer_filterbank,
-								tf_decomposition=tf_decomposition_filterbank,
-								)
-						self.logger.info('Performed T-F analysis of type %s'%tf_decomposition_filterbank)
-						for freq in eso.band_pass_filter_bank_pupil.keys():
-							bdf[eye+'_pupil_filterbank_bp_%2.5f'%freq] = eso.band_pass_filter_bank_pupil[freq]
-							self.logger.info('Saved T-F analysis %2.5f'%freq)
-					except:
-						self.logger.error('Something went wrong with T-F analysis of type %s'%tf_decomposition_filterbank)
-						pass
-					
-				# put in HDF5:
-				h5_file.put("/%s/block_%i"%(alias, i), bdf)
-	
-	def data_frame_to_hdf(self, alias, name, data_frame):
-		"""docstring for data_frame_to_hdf"""
-		with pd.get_store(self.input_object) as h5_file:
-			h5_file.put("/%s/%s"%(alias, name), data_frame)
-	
-	#
-	#	we also have to get the data from the hdf5 file. 
-	#	first, based on simply a EL timestamp period
-	#
-	
-	def sample_in_block(self, sample, block_table):
-		"""docstring for sample_in_block"""
-		return np.arange(block_table['block_end_timestamp'].shape[0])[np.array(block_table['block_end_timestamp'] > float(sample), dtype=bool)][0]
-	
-	def data_from_time_period(self, time_period, alias, columns = None):
-		"""data_from_time_period delivers a set of data of type data_type for a given timeperiod"""
-		# find the block in which the data resides, based on just the first time of time_period
-		with pd.get_store(self.input_object) as h5_file:
-			period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias]) 
-			table = h5_file['%s/block_%i'%(alias, period_block_nr)]
-			if columns == None:
-				columns = table.keys()
-		if 'L_vel' in columns:
-			columns = table.keys()
-		return table[(table['time'] > float(time_period[0])) & (table['time'] < float(time_period[1]))][columns]
-	
-	def eye_during_period(self, time_period, alias):
-		"""eye_during_period returns the identity of the eye that was recorded during a given period"""
-		with pd.get_store(self.input_object) as h5_file:
-			period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias])
-			eye = h5_file['%s/blocks'%alias]['eye_recorded'][period_block_nr]
-		return eye
-	
-	def eye_during_trial(self, trial_nr, alias):
-		"""docstring for signal_from_trial"""
-		with pd.get_store(self.input_object) as h5_file:
-			table = h5_file['%s/trials'%alias]
-			time_period = np.array(table[table['trial_start_index'] == trial_nr][['trial_start_EL_timestamp', 'trial_end_EL_timestamp']])
-		return self.eye_during_period(time_period[0], alias)
-
-	def screen_dimensions_during_period(self, time_period, alias):
-		"""docstring for eye_during_period"""
-		with pd.get_store(self.input_object) as h5_file:
-			period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias])
-			return np.array(h5_file['%s/blocks'%alias][['screen_x_pix','screen_y_pix']][period_block_nr:period_block_nr+1]).squeeze()
-
-	def screen_dimensions_during_trial(self, trial_nr, alias):
-		"""docstring for eye_during_period"""
-		with pd.get_store(self.input_object) as h5_file:
-			table = h5_file['%s/trials'%alias]
-			time_period = np.array(table[table['trial_start_index'] == trial_nr][['trial_start_EL_timestamp', 'trial_end_EL_timestamp']])[0]
-		return self.screen_dimensions_during_period(time_period = time_period, alias = alias)	
-	
-	def sample_rate_during_period(self, time_period, alias):
-		"""docstring for eye_during_period"""
-		with pd.get_store(self.input_object) as h5_file:
-			period_block_nr = self.sample_in_block(sample = time_period[0], block_table = h5_file['%s/blocks'%alias])
-			return h5_file['%s/blocks'%alias]['sample_rate'][period_block_nr]
-	
-	def sample_rate_during_trial(self, trial_nr, alias):
-		"""docstring for signal_from_trial"""
-		with pd.get_store(self.input_object) as h5_file:
-			table = h5_file['%s/trials'%alias]
-			time_period = np.array(table[table['trial_start_index'] == trial_nr][['trial_start_EL_timestamp', 'trial_end_EL_timestamp']])
-		return float(self.sample_rate_during_period(time_period[0], alias))
-	
-	def signal_during_period(self, time_period, alias, signal, requested_eye = 'L'):
-		"""docstring for gaze_during_period"""
-		recorded_eye = self.eye_during_period(time_period, alias)
-		if requested_eye == 'LR' and recorded_eye == 'LR':
-			if np.any([signal == 'gaze', signal == 'vel']):
-				columns = [s%signal for s in ['L_%s_x', 'L_%s_y', 'R_%s_x', 'R_%s_y']]
-			elif signal == 'time':
-				columns = [s%signal for s in ['%s']]		
-			else:
-				columns = [s%signal for s in ['L_%s', 'R_%s']]
-		elif requested_eye in recorded_eye:
-			if np.any([signal == 'gaze', signal == 'vel']):
-				columns = [s%signal for s in [requested_eye + '_%s_x', requested_eye + '_%s_y']]
-			elif signal == 'time':
-				columns = [s%signal for s in ['%s']]
-			else:
-				columns = [s%signal for s in [requested_eye + '_%s']]
-		else:
-			with pd.get_store(self.input_object) as h5_file:
-				self.logger.error('requested eye %s not found in block %i' % (requested_eye, self.sample_in_block(time_period[0], block_table = h5_file['%s/blocks'%alias])))
-			return None	# assert something, dammit!
-		return self.data_from_time_period(time_period, alias, columns)
-	
-	def saccades_during_period(self, time_period, alias, requested_eye = 'L', l = 5):
-		xy_data = self.signal_during_period(time_period = time_period, alias = alias, signal = 'gaze', requested_eye = requested_eye)
-		vel_data = self.signal_during_period(time_period = time_period, alias = alias, signal = 'vel', requested_eye = requested_eye) 
-		return detect_saccade_from_data(xy_data = xy_data, vel_data = vel_data, l = l, sample_rate = self.sample_rate_during_period(time_period, alias))
-
-	#
-	#	second, based also on trials, using the above functionality
-	#
-	
-	def signal_from_trial(self, trial_nr, alias, signal, requested_eye = 'L', time_extensions = [0,0]):
-		"""docstring for signal_from_trial"""
-		with pd.get_store(self.input_object) as h5_file:
-			table = h5_file['%s/trials'%alias]
-			time_period = np.array([
-				table[table['trial_start_index'] == trial_nr]['trial_start_EL_timestamp'] + time_extensions[0],
-				table[table['trial_start_index'] == trial_nr]['trial_end_EL_timestamp'] + time_extensions[1]
-			]).squeeze()
-		return self.signal_during_period(time_period, alias, signal, requested_eye = requested_eye)
-	
-	def time_period_for_trial_phases(self, trial_nr, trial_phases, alias ):
-		"""the time period corresponding to the trial phases requested.
-		"""
-		with pd.get_store(self.input_object) as h5_file:
-			table = h5_file['%s/trial_phases'%alias]
-			# check whether one of the trial phases is the end or the beginning of the trial.
-			# if so, then supplant the time of that phase with its trial's end or start time.
-			if trial_phases[0] == 0:
-				start_time = table[table['trial_start_index'] == trial_nr]['trial_start_EL_timestamp']
-			else:
-				start_time = table[((table['trial_phase_index'] == trial_phases[0]) * (table['trial_phase_trial'] == trial_nr))]['trial_phase_EL_timestamp']
-			if trial_phases[-1] == -1:
-				end_time = table[table['trial_start_index'] == trial_nr]['trial_end_EL_timestamp']
-			else:
-				end_time = table[((table['trial_phase_index'] == trial_phases[1]) * (table['trial_phase_trial'] == trial_nr))]['trial_phase_EL_timestamp']
-			time_period = np.array([np.array(start_time), np.array(end_time)]).squeeze()
-		return time_period
-
-	def signal_from_trial_phases(self, trial_nr, trial_phases, alias, signal, requested_eye = 'L', time_extensions = [0,0]):
-		"""docstring for signal_from_trial"""
-		time_period = self.time_period_for_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias)
-		time_period = np.array([time_period[0] + time_extensions[0], time_period[1] + time_extensions[1]]).squeeze()
-		return self.signal_during_period(time_period, alias, signal, requested_eye = requested_eye)
-	
-	def saccades_from_trial_phases(self, trial_nr, trial_phases, alias, requested_eye = 'L', time_extensions = [0,0], l = 5):
-		time_period = self.time_period_for_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias)
-		time_period = np.array([time_period[0] + time_extensions[0], time_period[1] + time_extensions[1]]).squeeze()
-		return self.saccades_during_period(time_period = time_period, alias = alias, requested_eye = requested_eye, time_extensions = time_extensions, l = l)
-
-		# xy_data = self.signal_from_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias, signal = 'gaze', requested_eye = requested_eye, time_extensions = time_extensions)
-		# vel_data = self.signal_from_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias, signal = 'vel', requested_eye = requested_eye, time_extensions = time_extensions) 
-		# return detect_saccade_from_data(xy_data = xy_data, vel_data = vel_data, l = l, sample_rate = self.sample_rate_during_period(self.time_period_for_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias), alias))
-			
-	#
-	#	read whole dataframes
-	#
-	
-	def read_session_data(self, alias, name):
-		"""
-		read_session_data reads data from the hdf5 file indicated by self.input_object.
-		Specifically, it reads the data associated with alias/name, with
-		'alias' and 'name' typically referring to a run (e.g. 'QQ241214') and
-		a data kind (e.g. 'trials'), respectively.
-		"""
-		
-		with pd.get_store(self.input_object) as h5_file:
-			session_data = h5_file['%s/%s'%(alias, name)]
-		return session_data
+        # xy_data = self.signal_from_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias, signal = 'gaze', requested_eye = requested_eye, time_extensions = time_extensions)
+        # vel_data = self.signal_from_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias, signal = 'vel', requested_eye = requested_eye, time_extensions = time_extensions) 
+        # return detect_saccade_from_data(xy_data = xy_data, vel_data = vel_data, l = l, sample_rate = self.sample_rate_during_period(self.time_period_for_trial_phases(trial_nr = trial_nr, trial_phases = trial_phases, alias = alias), alias))
+            
+    #
+    #    read whole dataframes
+    #
+    
+    def read_session_data(self, alias, name):
+        """
+        read_session_data reads data from the hdf5 file indicated by self.input_object.
+        Specifically, it reads the data associated with alias/name, with
+        'alias' and 'name' typically referring to a run (e.g. 'QQ241214') and
+        a data kind (e.g. 'trials'), respectively.
+        """
+        
+        with pd.get_store(self.input_object) as h5_file:
+            session_data = h5_file['%s/%s'%(alias, name)]
+        return session_data

--- a/src/HDFEyeOperator.py
+++ b/src/HDFEyeOperator.py
@@ -155,6 +155,7 @@ class HDFEyeOperator(Operator):
             pupil_hp = 0.01, 
             pupil_lp = 6,
             sample_rate = 1000.,
+            normalization = 'psc',
             minimal_frequency_filterbank = 0.0025, 
             maximal_frequency_filterbank = 0.1, 
             nr_freq_bins_filterbank = 9, 
@@ -237,27 +238,16 @@ class HDFEyeOperator(Operator):
                     # low-pass and band-pass pupil data:
                     eso.filter_pupil(hp=pupil_hp, lp=pupil_lp)
                     
-                    # now dt the resulting pupil data:
-                    eso.dt_pupil(dtype='lp_filt_pupil')
-                    eso.dt_pupil(dtype='bp_filt_pupil')
+                    # # now dt the resulting pupil data:
+                    # eso.dt_pupil(dtype='lp_filt_pupil')
+                    # eso.dt_pupil(dtype='bp_filt_pupil')
                     
                     # regress blink and saccade responses
-                    try:
-                        eso.regress_blinks()
-                    except:
-                        eso.lp_filt_pupil_clean = eso.lp_filt_pupil.copy()
-                        eso.bp_filt_pupil_clean = eso.bp_filt_pupil.copy()
-
-                    # zscore filtered pupil data:
-                    eso.zscore_pupil(dtype='lp_filt_pupil')
-                    eso.zscore_pupil(dtype='lp_filt_pupil_clean')
-                    eso.zscore_pupil(dtype='bp_filt_pupil')
-                    eso.zscore_pupil(dtype='bp_filt_pupil_clean')
-                    # percent signal change filtered pupil data:
-                    eso.percent_signal_change_pupil(dtype='lp_filt_pupil')
-                    eso.percent_signal_change_pupil(dtype='lp_filt_pupil_clean')
-                    eso.percent_signal_change_pupil(dtype='bp_filt_pupil')
-                    eso.percent_signal_change_pupil(dtype='bp_filt_pupil_clean')
+                    # try:
+                    eso.regress_blinks()
+                    # except:
+                    #     eso.lp_filt_pupil_clean = eso.lp_filt_pupil.copy()
+                    #     eso.bp_filt_pupil_clean = eso.bp_filt_pupil.copy()
                     
                     # add to existing dataframe:
                     bdf[eye+'_interpolated_timepoints'] = eso.interpolated_time_points
@@ -268,21 +258,33 @@ class HDFEyeOperator(Operator):
                     bdf[eye+'_gaze_y_int'] = eso.interpolated_y
                     
                     bdf[eye+'_pupil_lp'] = eso.lp_filt_pupil
-                    bdf[eye+'_pupil_lp_dt'] = eso.lp_filt_pupil_dt
-                    bdf[eye+'_pupil_lp_zscore'] = eso.lp_filt_pupil_zscore
-                    bdf[eye+'_pupil_lp_psc'] = eso.lp_filt_pupil_psc
+                    # bdf[eye+'_pupil_lp_dt'] = eso.lp_filt_pupil_dt
                     bdf[eye+'_pupil_lp_clean'] = eso.lp_filt_pupil_clean
-                    bdf[eye+'_pupil_lp_clean_zscore'] = eso.lp_filt_pupil_clean_zscore
-                    bdf[eye+'_pupil_lp_clean_psc'] = eso.lp_filt_pupil_clean_psc
                     
                     bdf[eye+'_pupil_bp'] = eso.bp_filt_pupil
-                    bdf[eye+'_pupil_bp_dt'] = eso.bp_filt_pupil_dt
-                    bdf[eye+'_pupil_bp_zscore'] = eso.bp_filt_pupil_zscore
-                    bdf[eye+'_pupil_bp_psc'] = eso.bp_filt_pupil_psc
+                    # bdf[eye+'_pupil_bp_dt'] = eso.bp_filt_pupil_dt
                     bdf[eye+'_pupil_bp_clean'] = eso.bp_filt_pupil_clean
-                    bdf[eye+'_pupil_bp_clean_zscore'] = eso.bp_filt_pupil_clean_zscore
-                    bdf[eye+'_pupil_bp_clean_psc'] = eso.bp_filt_pupil_clean_psc
                     
+                    # add normalized timeseries:
+                    if normalization == 'zcore':
+                        eso.zscore_pupil(dtype='lp_filt_pupil')
+                        eso.zscore_pupil(dtype='lp_filt_pupil_clean')
+                        eso.zscore_pupil(dtype='bp_filt_pupil')
+                        eso.zscore_pupil(dtype='bp_filt_pupil_clean')
+                        bdf[eye+'_pupil_lp_zscore'] = eso.lp_filt_pupil_zscore
+                        bdf[eye+'_pupil_lp_clean_zscore'] = eso.lp_filt_pupil_clean_zscore
+                        bdf[eye+'_pupil_bp_zscore'] = eso.bp_filt_pupil_zscore
+                        bdf[eye+'_pupil_bp_clean_zscore'] = eso.bp_filt_pupil_clean_zscore
+                    if normalization == 'psc':
+                        eso.percent_signal_change_pupil(dtype='lp_filt_pupil')
+                        eso.percent_signal_change_pupil(dtype='lp_filt_pupil_clean')
+                        eso.percent_signal_change_pupil(dtype='bp_filt_pupil')
+                        eso.percent_signal_change_pupil(dtype='bp_filt_pupil_clean')
+                        bdf[eye+'_pupil_lp_psc'] = eso.lp_filt_pupil_psc
+                        bdf[eye+'_pupil_lp_clean_psc'] = eso.lp_filt_pupil_clean_psc
+                        bdf[eye+'_pupil_bp_psc'] = eso.bp_filt_pupil_psc
+                        bdf[eye+'_pupil_bp_clean_psc'] = eso.bp_filt_pupil_clean_psc
+                        
                     # save summary plot:
                     fig = eso.summary_plot()
                     fig.savefig(os.path.join(os.path.split(self.input_object)[0], 'preprocess_{}_{}_{}.pdf'.format(alias, i, eye)))

--- a/src/Operator.py
+++ b/src/Operator.py
@@ -8,32 +8,31 @@ Copyright (c) 2010 __MyCompanyName__. All rights reserved.
 """
 
 import tempfile, logging
-
-# from nibabel import *
+import numpy as np
 from log import *
 
 class Operator( object ):
-	def __init__(self, input_object, **kwargs):
-		self.input_object = input_object
-		for k,v in kwargs.items():
-			setattr(self, k, v)
-			
-		# setup logging for this operator.
-		self.logger = logging.getLogger( self.__class__.__name__ )
-		self.logger.setLevel(logging.DEBUG)
-		loggingLevelSetup()
-		for handler in logging_handlers:
-			self.logger.addHandler(handler)
-	
-	def configure(self):
-		"""
-		placeholder for configure
-		to be filled in by subclasses
-		"""
-		pass
+    def __init__(self, input_object, **kwargs):
+        self.input_object = input_object
+        for k,v in kwargs.items():
+            setattr(self, k, v)
+            
+        # setup logging for this operator.
+        self.logger = logging.getLogger( self.__class__.__name__ )
+        self.logger.setLevel(logging.DEBUG)
+        loggingLevelSetup()
+        for handler in logging_handlers:
+            self.logger.addHandler(handler)
+    
+    def configure(self):
+        """
+        placeholder for configure
+        to be filled in by subclasses
+        """
+        pass
 
-	def execute(self):
-		"""
-		placeholder for execute
-		to be filled in by subclasses
-		"""
+    def execute(self):
+        """
+        placeholder for execute
+        to be filled in by subclasses
+        """


### PR DESCRIPTION
Streamlined functionalities. Specifically, one can now set (see example/pupil_preprocessing.py):
analysis_params = {
                'sample_rate' : 1000.0,
                'lp' : 6.0,
                'hp' : 0.01,
                'normalization' : 'psc', # save only psc or zscore in HDF5, to reduce filesize
                'regress_blinks' : True, # regress out pupil responses to blinks from pupil timeseries?
                'regress_sacs' : True, # regress out pupil responses to saccades from pupil timeseries?
                'regress_xy' : False, # regress out gaze timeseries from pupil timeseries?
                'use_standard_blinksac_kernels' : False, # use fitted blink / saccade responses, or standard as per PLOS ONE paper
                }